### PR TITLE
Responsive, redesigned stock list and shared UI components

### DIFF
--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
@@ -19,7 +19,6 @@ fun CurrentStockResponse.toDomain(): StockItem {
     val minStock = product?.minStockAmount ?: 0.0
 
     val hints = buildList {
-        add("${amount.formatAmount()} uds")
         if (amountOpened > 0) add("${amountOpened.toInt()} abierto")
         if (minStock > 0 && amount < minStock) add("bajo stock")
     }
@@ -39,7 +38,8 @@ fun CurrentStockResponse.toDomain(): StockItem {
         id = productId ?: 0,
         name = product?.name.orEmpty(),
         hints = hints,
-        consumptionDate = consumptionDate
+        consumptionDate = consumptionDate,
+        quantity = "${amount.formatAmount()} uds"
     )
 }
 

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/stock/StockItem.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/stock/StockItem.kt
@@ -6,5 +6,6 @@ data class StockItem(
     val id: Int,
     val name: String,
     val hints: List<String>,
-    val consumptionDate: ConsumptionDate?
+    val consumptionDate: ConsumptionDate?,
+    val quantity: String
 )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/AppIcon.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/AppIcon.kt
@@ -12,7 +12,7 @@ import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun AppIcon(
+internal fun AppIcon(
     size: Dp
 ) {
     //TODO

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/DotsPager.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/DotsPager.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun DotsPager(
+internal fun DotsPager(
     modifier: Modifier = Modifier, // <- expón el modifier
     pageCount: Int,
     content: @Composable (page: Int) -> Unit

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/HintCard.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/HintCard.kt
@@ -9,12 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 
 @Composable
-fun HintCard(
+internal fun HintCard(
     text: String,
     modifier: Modifier = Modifier,
     containerColor: Color = MaterialTheme.colorScheme.secondaryContainer,
@@ -29,14 +30,15 @@ fun HintCard(
         Text(
             text = text,
             modifier = Modifier.padding(MaterialTheme.spacing.s2),
-            style = textStyle
+            style = textStyle,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }
 
 @PreviewLightDark
 @Composable
-fun HintCardPreview() {
+private fun HintCardPreview() {
     KrocyTheme {
         HintCard(
             text = "5 Packs",

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
@@ -1,0 +1,23 @@
+package com.srfmolina.krocy.ui.presentation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import com.srfmolina.krocy.ui.presentation.theme.spacing
+
+@Composable
+fun PhotoHolder(size: Dp, modifier: Modifier = Modifier, cornerRadius: Dp = MaterialTheme.spacing.s3) {
+    val shape = RoundedCornerShape(cornerRadius)
+    Box(
+        modifier = modifier
+            .size(size)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh, shape)
+            .border(MaterialTheme.spacing.s0, MaterialTheme.colorScheme.outlineVariant, shape)
+    )
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.unit.Dp
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 
 @Composable
-fun PhotoHolder(size: Dp, modifier: Modifier = Modifier, cornerRadius: Dp = MaterialTheme.spacing.s3) {
+internal fun PhotoHolder(size: Dp, modifier: Modifier = Modifier, cornerRadius: Dp = MaterialTheme.spacing.s3) {
     val shape = RoundedCornerShape(cornerRadius)
     Box(
         modifier = modifier

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/TheeDotsMenuButton.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/TheeDotsMenuButton.kt
@@ -1,0 +1,128 @@
+package com.srfmolina.krocy.ui.presentation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
+import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+
+@Composable
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+internal fun TheeDotsMenuButton(
+    actions: List<LabeledActionUi>
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        IconButton(
+            onClick = { expanded = true },
+            shapes = IconButtonDefaults.shapes()
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        if (actions.isNotEmpty()) {
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                actions.forEach { action ->
+                    DropdownMenuItem(
+                        text = { Text(action.label) },
+                        leadingIcon = action.icon?.let { icon ->
+                            {
+                                Icon(
+                                    imageVector = icon,
+                                    contentDescription = action.contentDescription
+                                )
+                            }
+                        },
+                        onClick = {
+                            expanded = false
+                            action.onClick()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun TheeDotsMenuButtonPreview() {
+    KrocyTheme {
+        Row(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxWidth()
+                .height(320.dp)
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Text(
+                text = "Item label",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(top = 16.dp)
+            )
+            TheeDotsMenuButton(
+                actions = listOf(
+                LabeledActionUi(
+                    label = "Edit",
+                    contentDescription = "Edit item",
+                    icon = Icons.Default.Edit,
+                    onClick = {}
+                ),
+                LabeledActionUi(
+                    label = "Share",
+                    contentDescription = "Share item",
+                    icon = Icons.Default.Share,
+                    onClick = {}
+                ),
+                LabeledActionUi(
+                    label = "No icon",
+                    contentDescription = "Action without icon",
+                    onClick = {}
+                ),
+                LabeledActionUi(
+                    label = "Delete",
+                    contentDescription = "Delete item",
+                    icon = Icons.Default.Delete,
+                    onClick = {}
+                )
+                )
+            )
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/IconActionUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/IconActionUi.kt
@@ -2,7 +2,7 @@ package com.srfmolina.krocy.ui.presentation.common.model
 
 import androidx.compose.ui.graphics.vector.ImageVector
 
-internal data class ActionUi(
+internal data class IconActionUi(
     val icon: ImageVector,
     val contentDescription: String,
     val onClick: () -> Unit

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/LabeledActionUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/LabeledActionUi.kt
@@ -1,0 +1,10 @@
+package com.srfmolina.krocy.ui.presentation.common.model
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class LabeledActionUi(
+    val label: String,
+    val contentDescription: String,
+    val icon: ImageVector? = null,
+    val onClick: () -> Unit
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -67,14 +67,20 @@ private fun StockScreen(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s3)
         ) {
             items(items) { item ->
-                StockItemComp(item)
+                StockItemComp(
+                    modifier = Modifier.padding(MaterialTheme.spacing.s3),
+                    item = item
+                )
             }
         }
     } else {
         @OptIn(ExperimentalFoundationApi::class)
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             itemsIndexed(items) { index, item ->
-                StockItemComp(item)
+                StockItemComp(
+                    modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    item = item
+                )
                 if (index < items.lastIndex) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
-import com.srfmolina.krocy.ui.presentation.common.model.ActionUi
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
 import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
+import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel.Event
 import com.srfmolina.krocy.ui.presentation.feature.stock.component.StockItemComp
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
@@ -45,7 +45,7 @@ internal fun StockScreen(
         onChangeTopBar(TopBarConfigurationUi(
             title = "Resumen del inventario",
             type = TopBarTypeUi.SMALL,
-            leadingAction = ActionUi(
+            leadingAction = IconActionUi(
                 icon = Icons.Filled.Menu,
                 contentDescription = "Localized description", //TODO
                 onClick = onOpenNavRail

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -1,12 +1,15 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -18,12 +21,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
 import com.srfmolina.krocy.ui.presentation.common.model.ActionUi
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
+import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel.Event
 import com.srfmolina.krocy.ui.presentation.feature.stock.component.StockItemComp
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarTypeUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.displaySize
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -56,12 +61,24 @@ internal fun StockScreen(
 private fun StockScreen(
     items: List<StockItemUi>
 ) {
-    LazyColumn (
-        modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.s4),
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s6)
-    ) {
-        items(items) { item ->
-            StockItemComp(item)
+    if (MaterialTheme.displaySize == DisplaySizeUi.S) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.s4),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s3)
+        ) {
+            items(items) { item ->
+                StockItemComp(item)
+            }
+        }
+    } else {
+        @OptIn(ExperimentalFoundationApi::class)
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            itemsIndexed(items) { index, item ->
+                StockItemComp(item)
+                if (index < items.lastIndex) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
+            }
         }
     }
 }
@@ -87,7 +104,8 @@ private fun StockScreenPreview() {
                             )
                         } else {
                             null
-                        }
+                        },
+                        quantity = "3 Packs"
                     )
                 }
             )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -9,16 +9,12 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -34,6 +30,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
 import com.srfmolina.krocy.ui.presentation.common.HintCard
 import com.srfmolina.krocy.ui.presentation.common.PhotoHolder
+import com.srfmolina.krocy.ui.presentation.common.TheeDotsMenuButton
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
 import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
@@ -50,7 +47,7 @@ internal fun StockItemComp(
     if (MaterialTheme.displaySize == DisplaySizeUi.S) {
         StockItemCompact(item, modifier)
     } else {
-        StockItemDenseRow(item, modifier)
+        StockItemRow(item, modifier)
     }
 }
 
@@ -76,7 +73,6 @@ private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -86,61 +82,71 @@ private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
                 ) {
-                    ExpiryChip(item.consumptionDate, dense = false)
+                    ExpiryChip(item.consumptionDate)
 
                     Text(
                         text = "·",
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
+                    HintCard(
+                        text = item.quantity,
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
 
                     Text(
-                        text = item.quantity,
+                        text = "·",
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
                     )
+
+                    RowOfHints(item.hints)
 
                 }
             }
         }
-        IconButton(
-            onClick = {},
-            shapes = IconButtonDefaults.shapes()
-        ) {
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+        TheeDotsMenuButton(actions = emptyList()) //TODO
+    }
+}
+
+@Composable
+private fun RowOfHints(
+    hints: List<String>,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
+        modifier = modifier
+    ) {
+        items(hints) { hint ->
+            HintCard(
+                text = hint,
             )
         }
     }
 }
 
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun StockItemDenseRow(item: StockItemUi, modifier: Modifier = Modifier) {
+private fun StockItemRow(item: StockItemUi, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(MaterialTheme.spacing.s14)
+            .height(MaterialTheme.spacing.s18)
             .padding(horizontal = MaterialTheme.spacing.s4),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
     ) {
-        PhotoHolder(size = MaterialTheme.spacing.s10) //TODO
+        PhotoHolder(size = MaterialTheme.spacing.s12) //TODO
         Text(
             text = item.name,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.weight(1f),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
         Box(modifier = Modifier.width(MaterialTheme.spacing.s32)) {
-            item.consumptionDate?.let { ExpiryChip(it, dense = true) }
+            item.consumptionDate?.let { ExpiryChip(it) }
         }
         Text(
             text = item.quantity,
@@ -150,35 +156,21 @@ private fun StockItemDenseRow(item: StockItemUi, modifier: Modifier = Modifier) 
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-        Text(
-            text = item.hints.getOrNull(1) ?: "—",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.width(MaterialTheme.spacing.s28),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-        IconButton(
-            onClick = {},
-            shapes = IconButtonDefaults.shapes(),
-            modifier = Modifier.size(MaterialTheme.spacing.s12)
-        ) { //TODO
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+
+        Box(modifier = Modifier.width(MaterialTheme.spacing.s28)) {
+            RowOfHints(item.hints)
         }
+
+        TheeDotsMenuButton(actions = emptyList()) //TODO
     }
 }
 
 @Composable
-private fun ExpiryChip(consumptionDate: ConsumptionDateUi, dense: Boolean) {
+private fun ExpiryChip(consumptionDate: ConsumptionDateUi) {
     val containerColor = expiryHintColor(consumptionDate)
     HintCard(
         text = consumptionDate.date,
         containerColor = containerColor,
-        textStyle = if (dense) MaterialTheme.typography.labelSmall else MaterialTheme.typography.labelMedium
     )
 
 }
@@ -262,11 +254,11 @@ private fun StockItemCompactPreview(
 
 @PreviewLightDark
 @Composable
-private fun StockItemDensePreview() {
+private fun StockItemRowPreview() {
     KrocyTheme {
         Surface {
             Column {
-                StockItemDenseRow(
+                StockItemRow(
                     StockItemUi(
                         id = 1, name = "Galletas María",
                         hints = listOf("2 paquetes", "1 abierto"),
@@ -275,7 +267,7 @@ private fun StockItemDensePreview() {
                     )
                 )
                 HorizontalDivider()
-                StockItemDenseRow(
+                StockItemRow(
                     StockItemUi(
                         id = 2, name = "Yogur natural",
                         hints = listOf("8 unidades", "2 abiertos"),
@@ -284,7 +276,7 @@ private fun StockItemDensePreview() {
                     )
                 )
                 HorizontalDivider()
-                StockItemDenseRow(
+                StockItemRow(
                     StockItemUi(
                         id = 3, name = "Leche entera",
                         hints = listOf("3 briks", "1 abierto"),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -1,18 +1,13 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -21,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -54,70 +48,58 @@ internal fun StockItemComp(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
-    val shape = RoundedCornerShape(MaterialTheme.spacing.s4)
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .defaultMinSize(minHeight = MaterialTheme.spacing.s18)
-            .clip(shape)
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(MaterialTheme.spacing.s3),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
-    ) {
-        PhotoHolder(size = MaterialTheme.spacing.s18) //TODO
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
+
+    Surface {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
         ) {
-            Text(
-                text = item.name,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            val hasExpiry = item.consumptionDate != null
-            if (hasExpiry) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
-                ) {
-                    ExpiryChip(item.consumptionDate)
+            PhotoHolder(size = MaterialTheme.spacing.s18) //TODO
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
+            ) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
 
-                    Text(
-                        text = "·",
-                        style = MaterialTheme.typography.labelMedium,
-                    )
+                RowOfHints(item)
 
-                    HintCard(
-                        text = item.quantity,
-                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                    )
-
-                    Text(
-                        text = "·",
-                        style = MaterialTheme.typography.labelMedium,
-                    )
-
-                    RowOfHints(item.hints)
-
-                }
             }
+            TheeDotsMenuButton(actions = emptyList()) //TODO
         }
-        TheeDotsMenuButton(actions = emptyList()) //TODO
     }
 }
 
 @Composable
 private fun RowOfHints(
-    hints: List<String>,
-    modifier: Modifier = Modifier
+    item: StockItemUi
 ) {
+
+    val hasExpiry = item.consumptionDate != null
+
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
-        modifier = modifier
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
     ) {
-        items(hints) { hint ->
+        item {
+            if (hasExpiry) {
+                ExpiryChip(item.consumptionDate)
+            }
+        }
+
+        item {
+            HintCard(
+                text = item.quantity,
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            )
+        }
+
+        items(item.hints) { hint ->
             HintCard(
                 text = hint,
             )
@@ -131,9 +113,7 @@ private fun RowOfHints(
 private fun StockItemRow(item: StockItemUi, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
-            .fillMaxWidth()
-            .height(MaterialTheme.spacing.s18)
-            .padding(horizontal = MaterialTheme.spacing.s4),
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
     ) {
@@ -145,21 +125,10 @@ private fun StockItemRow(item: StockItemUi, modifier: Modifier = Modifier) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-        Box(modifier = Modifier.width(MaterialTheme.spacing.s32)) {
-            item.consumptionDate?.let { ExpiryChip(it) }
-        }
-        Text(
-            text = item.quantity,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.width(MaterialTheme.spacing.s28),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
 
-        Box(modifier = Modifier.width(MaterialTheme.spacing.s28)) {
-            RowOfHints(item.hints)
-        }
+        Spacer(Modifier.weight(1f))
+
+        RowOfHints(item)
 
         TheeDotsMenuButton(actions = emptyList()) //TODO
     }
@@ -240,7 +209,8 @@ private fun StockItemCompactPreview(
     KrocyTheme {
         Surface {
             StockItemCompact(
-                StockItemUi(
+                modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                item = StockItemUi(
                     id = 0,
                     name = "Galletas María",
                     hints = item.hints,
@@ -259,7 +229,8 @@ private fun StockItemRowPreview() {
         Surface {
             Column {
                 StockItemRow(
-                    StockItemUi(
+                    modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    item = StockItemUi(
                         id = 1, name = "Galletas María",
                         hints = listOf("2 paquetes", "1 abierto"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", expired = false),
@@ -268,7 +239,8 @@ private fun StockItemRowPreview() {
                 )
                 HorizontalDivider()
                 StockItemRow(
-                    StockItemUi(
+                    modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    item = StockItemUi(
                         id = 2, name = "Yogur natural",
                         hints = listOf("8 unidades", "2 abiertos"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", expired = false),
@@ -277,7 +249,8 @@ private fun StockItemRowPreview() {
                 )
                 HorizontalDivider()
                 StockItemRow(
-                    StockItemUi(
+                    modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    item = StockItemUi(
                         id = 3, name = "Leche entera",
                         hints = listOf("3 briks", "1 abierto"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", expired = true),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -1,71 +1,205 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
 import com.srfmolina.krocy.ui.presentation.common.HintCard
+import com.srfmolina.krocy.ui.presentation.common.PhotoHolder
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
+import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.displaySize
 import com.srfmolina.krocy.ui.presentation.theme.extendedColorScheme
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun StockItemComp(
     item: StockItemUi,
     modifier: Modifier = Modifier
 ) {
+    if (MaterialTheme.displaySize == DisplaySizeUi.S) {
+        StockItemCompact(item, modifier)
+    } else {
+        StockItemDenseRow(item, modifier)
+    }
+}
 
-    val showRow = (item.consumptionDate != null) || item.hints.isNotEmpty()
-
-    Column (
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
+    val shape = RoundedCornerShape(MaterialTheme.spacing.s4)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = MaterialTheme.spacing.s18)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .padding(MaterialTheme.spacing.s3),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
     ) {
-        Text(
-            text = item.name,
-            style = MaterialTheme.typography.titleMedium
-        )
+        PhotoHolder(size = MaterialTheme.spacing.s18) //TODO
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
+        ) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            val hasExpiry = item.consumptionDate != null
+            if (hasExpiry) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
+                ) {
+                    ExpiryChip(item.consumptionDate, dense = false)
 
-        if (showRow) {
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
-            ) {
-                item.consumptionDate?.let {
-                    val containerColor = when {
-                        it.expired -> MaterialTheme.colorScheme.errorContainer
-                        it.type == ConsumptionType.EXPIRATION -> MaterialTheme.extendedColorScheme.danger.colorContainer
-                        it.type == ConsumptionType.PREFERENCE -> MaterialTheme.extendedColorScheme.warning.colorContainer
-                        else -> MaterialTheme.colorScheme.error
-                    }
-                    HintCard(
-                        text = it.date,
-                        containerColor = containerColor
+                    Text(
+                        text = "·",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
 
-                item.hints.forEach { hint ->
-                    HintCard(
-                        text = hint
+
+                    Text(
+                        text = item.quantity,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
+
                 }
             }
         }
+        IconButton(
+            onClick = {},
+            shapes = IconButtonDefaults.shapes()
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun StockItemDenseRow(item: StockItemUi, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(MaterialTheme.spacing.s14)
+            .padding(horizontal = MaterialTheme.spacing.s4),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
+    ) {
+        PhotoHolder(size = MaterialTheme.spacing.s10) //TODO
+        Text(
+            text = item.name,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Box(modifier = Modifier.width(MaterialTheme.spacing.s32)) {
+            item.consumptionDate?.let { ExpiryChip(it, dense = true) }
+        }
+        Text(
+            text = item.quantity,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(MaterialTheme.spacing.s28),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = item.hints.getOrNull(1) ?: "—",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(MaterialTheme.spacing.s28),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        IconButton(
+            onClick = {},
+            shapes = IconButtonDefaults.shapes(),
+            modifier = Modifier.size(MaterialTheme.spacing.s12)
+        ) { //TODO
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExpiryChip(consumptionDate: ConsumptionDateUi, dense: Boolean) {
+    val containerColor = expiryHintColor(consumptionDate)
+    HintCard(
+        text = consumptionDate.date,
+        containerColor = containerColor,
+        textStyle = if (dense) MaterialTheme.typography.labelSmall else MaterialTheme.typography.labelMedium
+    )
+
+}
+
+@Composable
+private fun expiryHintColor(consumptionDate: ConsumptionDateUi): Color {
+    val cs = MaterialTheme.colorScheme
+    val ext = MaterialTheme.extendedColorScheme
+    return when {
+        consumptionDate.expired ->
+            cs.errorContainer
+        consumptionDate.type == ConsumptionType.EXPIRATION ->
+            ext.danger.colorContainer
+        consumptionDate.type == ConsumptionType.PREFERENCE ->
+            ext.warning.colorContainer
+        else ->
+            cs.secondaryContainer
+    }
+}
+
+
 
 // PREVIEW //
 
@@ -77,28 +211,26 @@ private data class StockItemCompPPPI(
 private class StockItemCompPPP : PreviewParameterProvider<StockItemCompPPPI> {
     override val values: Sequence<StockItemCompPPPI> = sequenceOf(
         StockItemCompPPPI(),
+        StockItemCompPPPI(hints = emptyList()),
         StockItemCompPPPI(
-            hints = listOf("1 Pack")
-        ),
-        StockItemCompPPPI(
-            hints = listOf("2 Paquetes", "1 abierto"),
-            ConsumptionDateUi(
+            hints = listOf("1 abierto"),
+            consumptionDate = ConsumptionDateUi(
                 type = ConsumptionType.PREFERENCE,
                 date = "En 2 días",
                 expired = false
             )
         ),
         StockItemCompPPPI(
-            hints = listOf("2 Paquetes", "1 abierto"),
-            ConsumptionDateUi(
+            hints = listOf("1 abierto"),
+            consumptionDate = ConsumptionDateUi(
                 type = ConsumptionType.EXPIRATION,
                 date = "En 2 días",
                 expired = false
             )
         ),
         StockItemCompPPPI(
-            hints = listOf("2 Paquetes", "1 abierto"),
-            ConsumptionDateUi(
+            hints = listOf("2 abiertos"),
+            consumptionDate = ConsumptionDateUi(
                 type = ConsumptionType.EXPIRATION,
                 date = "Hace 1 día",
                 expired = true
@@ -109,20 +241,58 @@ private class StockItemCompPPP : PreviewParameterProvider<StockItemCompPPPI> {
 
 @PreviewLightDark
 @Composable
-private fun StockItemCompPreview(
+private fun StockItemCompactPreview(
     @PreviewParameter(StockItemCompPPP::class)
     item: StockItemCompPPPI
 ) {
     KrocyTheme {
         Surface {
-            StockItemComp(
+            StockItemCompact(
                 StockItemUi(
                     id = 0,
-                    name = "Galletas",
+                    name = "Galletas María",
                     hints = item.hints,
-                    consumptionDate = item.consumptionDate
+                    consumptionDate = item.consumptionDate,
+                    quantity = "3 Packs"
                 )
             )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun StockItemDensePreview() {
+    KrocyTheme {
+        Surface {
+            Column {
+                StockItemDenseRow(
+                    StockItemUi(
+                        id = 1, name = "Galletas María",
+                        hints = listOf("2 paquetes", "1 abierto"),
+                        consumptionDate = ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", expired = false),
+                        quantity = "2 paquetes"
+                    )
+                )
+                HorizontalDivider()
+                StockItemDenseRow(
+                    StockItemUi(
+                        id = 2, name = "Yogur natural",
+                        hints = listOf("8 unidades", "2 abiertos"),
+                        consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", expired = false),
+                        quantity = "3 uds"
+                    )
+                )
+                HorizontalDivider()
+                StockItemDenseRow(
+                    StockItemUi(
+                        id = 3, name = "Leche entera",
+                        hints = listOf("3 briks", "1 abierto"),
+                        consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", expired = true),
+                        quantity = "2 uds"
+                    )
+                )
+            }
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/mapper/StockUiMapper.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/mapper/StockUiMapper.kt
@@ -13,7 +13,8 @@ internal fun StockItem.toUi(): StockItemUi = StockItemUi(
     id = id,
     name = name,
     hints = hints,
-    consumptionDate = consumptionDate?.toUi()
+    consumptionDate = consumptionDate?.toUi(),
+    quantity = quantity
 )
 
 private fun ConsumptionDate.toUi(): ConsumptionDateUi = ConsumptionDateUi(

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/model/StockItemUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/model/StockItemUi.kt
@@ -6,5 +6,6 @@ internal data class StockItemUi(
     val id: Int,
     val name: String,
     val hints: List<String>,
-    val consumptionDate: ConsumptionDateUi?
+    val consumptionDate: ConsumptionDateUi?,
+    val quantity: String
 )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/NavigationRail.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/NavigationRail.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -54,14 +53,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
+import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
 import com.srfmolina.krocy.ui.presentation.navigation.KrocyRoute
 import com.srfmolina.krocy.ui.presentation.navigation.NavigationItemUi
 import com.srfmolina.krocy.ui.presentation.navigation.SplashRoute
 import com.srfmolina.krocy.ui.presentation.navigation.StockRoute
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.displaySize
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 
-private val COMPACT_BREAKPOINT = 600.dp
 private val RAIL_COLLAPSED_WIDTH = 80.dp
 private val RAIL_EXPANDED_WIDTH = 240.dp
 private const val ANIM_DURATION_MS = 300
@@ -93,10 +93,10 @@ internal fun KrocyNavigationRail(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    BoxWithConstraints(
+    Box(
         modifier = modifier.fillMaxSize()
     ) {
-        val isCompact = maxWidth < COMPACT_BREAKPOINT
+        val isCompact = MaterialTheme.displaySize == DisplaySizeUi.S
         var wideExpanded by rememberSaveable { mutableStateOf(false) }
 
         if (isCompact) {

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/NavigationRail.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/NavigationRail.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
@@ -175,6 +176,7 @@ private fun CompactLayout(
                 showLabels = true,
                 onItemSelected = onItemSelected,
                 menuIcon = Icons.AutoMirrored.Filled.MenuOpen,
+                menuIconPadding = MaterialTheme.spacing.s2,
                 menuContentDescription = "Close navigation menu",
                 onMenuClick = onCollapse,
             )
@@ -215,6 +217,7 @@ private fun WideLayout(
             labelRevealProgress = labelRevealProgress,
             onItemSelected = onItemSelected,
             menuIcon = if (expanded) Icons.AutoMirrored.Filled.MenuOpen else Icons.Filled.Menu,
+            menuIconPadding = MaterialTheme.spacing.s4,
             menuContentDescription = if (expanded) "Collapse navigation" else "Expand navigation",
             onMenuClick = onToggle,
         )
@@ -246,6 +249,7 @@ private fun RailPanel(
     showLabels: Boolean,
     onItemSelected: (NavigationItemUi) -> Unit,
     menuIcon: ImageVector,
+    menuIconPadding: Dp,
     menuContentDescription: String,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -261,12 +265,11 @@ private fun RailPanel(
                 .fillMaxSize()
                 .padding(vertical = MaterialTheme.spacing.s2),
         ) {
-            // Button pinned to top-left of the panel (= screen top-left corner)
-            // so it never moves as the rail animates its width
+
             IconButton(
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .padding(horizontal = MaterialTheme.spacing.s4),
+                    .padding(horizontal = menuIconPadding),
                 onClick = onMenuClick,
                 shapes = IconButtonDefaults.shapes()
             ) {
@@ -337,8 +340,7 @@ private fun RailItem(
                 imageVector = item.icon,
                 contentDescription = item.contentDescription,
             )
-            // Clip-grow container: layout width animates from 0 → intrinsic width,
-            // revealing the label as the rail expands (no pixel compression)
+
             Row(
                 modifier = Modifier
                     .layout { measurable, constraints ->

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/topbar/TopBar.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/topbar/TopBar.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.srfmolina.krocy.ui.presentation.common.model.ActionUi
 import com.srfmolina.krocy.ui.presentation.common.model.DisplaySizeUi
+import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
 import com.srfmolina.krocy.ui.presentation.theme.displaySize
 
@@ -38,8 +38,8 @@ import com.srfmolina.krocy.ui.presentation.theme.displaySize
 internal fun SmallTopBar(
     title: String,
     scrollBehavior: TopAppBarScrollBehavior,
-    navigationAction: ActionUi, //TODO: hide menu icon leading actions in larger screens
-    trailingAction: ActionUi? = null
+    navigationAction: IconActionUi, //TODO: hide menu icon leading actions in larger screens
+    trailingAction: IconActionUi? = null
 ) {
     CenterAlignedTopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(),
@@ -73,8 +73,8 @@ internal fun SmallTopBar(
 internal fun MediumTopBar(
     title: String,
     scrollBehavior: TopAppBarScrollBehavior,
-    navigationAction: ActionUi,
-    action: ActionUi? = null
+    navigationAction: IconActionUi,
+    action: IconActionUi? = null
 ) {
     MediumTopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(),
@@ -105,7 +105,7 @@ internal fun MediumTopBar(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun NavigationIcon(navigationAction: ActionUi) {
+private fun NavigationIcon(navigationAction: IconActionUi) {
     if (MaterialTheme.displaySize == DisplaySizeUi.S || navigationAction.icon != Icons.Filled.Menu) {
         IconButton(
             onClick = navigationAction.onClick,
@@ -135,12 +135,12 @@ fun SmallTopBarPreview() {
                 SmallTopBar(
                     title = "Small top bar",
                     scrollBehavior = scrollBehavior,
-                    navigationAction = ActionUi(
+                    navigationAction = IconActionUi(
                         icon = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "example",
                         onClick = {}
                     ),
-                    trailingAction = ActionUi(
+                    trailingAction = IconActionUi(
                         icon = Icons.Filled.Menu,
                         contentDescription = "example",
                         onClick = {}
@@ -182,12 +182,12 @@ fun MediumTopBarPreview() {
                 MediumTopBar(
                     title = "Medium top bar",
                     scrollBehavior = scrollBehavior,
-                    navigationAction = ActionUi(
+                    navigationAction = IconActionUi(
                         icon = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "example",
                         onClick = {}
                     ),
-                    action = ActionUi(
+                    action = IconActionUi(
                         icon = Icons.Filled.Menu,
                         contentDescription = "example",
                         onClick = {}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/topbar/model/TopBarConfigurationUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/topbar/model/TopBarConfigurationUi.kt
@@ -1,11 +1,11 @@
 package com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import com.srfmolina.krocy.ui.presentation.common.model.ActionUi
+import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
 
 internal data class TopBarConfigurationUi @OptIn(ExperimentalMaterial3Api::class) constructor(
     val title: String,
     val type: TopBarTypeUi,
-    val leadingAction: ActionUi,
-    val trailingAction: ActionUi? = null
+    val leadingAction: IconActionUi,
+    val trailingAction: IconActionUi? = null
 )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/theme/Spacing.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/theme/Spacing.kt
@@ -22,7 +22,7 @@ data class KrocySpacing(
     val s14: Dp = 56.dp,
     val s18: Dp = 72.dp,
     val s28: Dp = 112.dp,
-    val s32: Dp = 128.dp
+    val s32: Dp = 128.dp,
 )
 
 val MaterialTheme.spacing: KrocySpacing

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/theme/Spacing.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/theme/Spacing.kt
@@ -17,7 +17,12 @@ data class KrocySpacing(
     val s4: Dp = 16.dp,
     val s6: Dp = 24.dp,
     val s8: Dp = 32.dp,
-    val s12: Dp = 48.dp
+    val s10: Dp = 40.dp,
+    val s12: Dp = 48.dp,
+    val s14: Dp = 56.dp,
+    val s18: Dp = 72.dp,
+    val s28: Dp = 112.dp,
+    val s32: Dp = 128.dp
 )
 
 val MaterialTheme.spacing: KrocySpacing


### PR DESCRIPTION
## Summary

UI polish for the stock screen and shared components, plus a few supporting refactors. The stock list now adapts to screen size with two distinct layouts and richer item rows.

## Changes

### Stock screen
- **Responsive layouts**: `StockItemComp` now renders a compact layout on small screens and a row layout on larger ones, selected via `MaterialTheme.displaySize` rather than width breakpoints.
- **Richer item rows**: each item shows a photo placeholder (`PhotoHolder`), the product name, a horizontally scrolling row of hint chips (quantity, expiry, "abierto", "bajo stock"), and a three-dots overflow menu.
- **Dedicated quantity field**: amount is now a first-class `quantity` field on `StockItem` / `StockItemUi` (and its mappers) instead of being mixed into `hints`, and is rendered as a highlighted chip.
- Wide-screen list adds `HorizontalDivider`s between items.

### Shared components
- New `PhotoHolder` — rounded placeholder box for product images (TODO: real images).
- New `TheeDotsMenuButton` — dropdown overflow menu driven by a list of actions.
- New `LabeledActionUi` model; renamed `ActionUi` → `IconActionUi` for clarity, updated all usages (top bar, stock screen).
- `HintCard` truncates overflowing text with an ellipsis.
- Tightened visibility (`internal` / `private`) on several composables and previews.

### Navigation & theme
- `KrocyNavigationRail` now uses `MaterialTheme.displaySize` instead of `BoxWithConstraints` to decide compact vs. wide, and the menu icon padding is parameterized per layout.
- Added spacing tokens (`s10`, `s14`, `s18`, `s28`, `s32`).

## Notes
- Several `//TODO`s remain for real product images and wiring up the overflow menu actions.
