### PR TITLE
Stock actions, product pictures, loading skeletons and FAB menu

### DIFF
--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDataSource.kt
@@ -1,0 +1,7 @@
+package com.srfmolina.krocy.data.datasource.remote.generic
+
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+
+internal interface GenericEntityDataSource {
+    suspend fun getQuantityUnits(): Result<List<ObjectsEntityGet200ResponseInner>>
+}

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.srfmolina.krocy.data.datasource.remote.generic
+
+import org.openapitools.client.apis.GenericEntityInteractionsApi
+import org.openapitools.client.models.ExposedEntity
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+
+internal class GenericEntityDataSourceImpl(private val api: GenericEntityInteractionsApi): GenericEntityDataSource {
+    override suspend fun getQuantityUnits(): Result<List<ObjectsEntityGet200ResponseInner>> = runCatching {
+        api.objectsEntityGet(entity = ExposedEntity.quantity_units).body()
+    }
+}

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSource.kt
@@ -1,7 +1,10 @@
 package com.srfmolina.krocy.data.datasource.remote.stock
 
 import org.openapitools.client.models.CurrentStockResponse
+import org.openapitools.client.models.StockLogEntry
 
 internal interface StockDataSource {
     suspend fun getStock(): Result<List<CurrentStockResponse>>
+
+    suspend fun consume(productId: Int): Result<List<StockLogEntry>>
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSource.kt
@@ -6,5 +6,9 @@ import org.openapitools.client.models.StockLogEntry
 internal interface StockDataSource {
     suspend fun getStock(): Result<List<CurrentStockResponse>>
 
-    suspend fun consume(productId: Int): Result<List<StockLogEntry>>
+    suspend fun consume(productId: Int, amount: Double): Result<List<StockLogEntry>>
+
+    suspend fun open(productId: Int, amount: Double): Result<List<StockLogEntry>>
+
+    suspend fun add(productId: Int, amount: Double): Result<List<StockLogEntry>>
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSourceImpl.kt
@@ -3,18 +3,38 @@ package com.srfmolina.krocy.data.datasource.remote.stock
 import org.openapitools.client.apis.StockApi
 import org.openapitools.client.models.CurrentStockResponse
 import org.openapitools.client.models.StockLogEntry
+import org.openapitools.client.models.StockProductsProductIdAddPostRequest
 import org.openapitools.client.models.StockProductsProductIdConsumePostRequest
+import org.openapitools.client.models.StockProductsProductIdOpenPostRequest
 
 internal class StockDataSourceImpl(private val api: StockApi): StockDataSource {
     override suspend fun getStock(): Result<List<CurrentStockResponse>> = runCatching {
         api.stockGet().body()
     }
 
-    override suspend fun consume(productId: Int): Result<List<StockLogEntry>> = runCatching {
+    override suspend fun consume(productId: Int, amount: Double): Result<List<StockLogEntry>> = runCatching {
         api.stockProductsProductIdConsumePost(
             productId = productId,
             stockProductsProductIdConsumePostRequest = StockProductsProductIdConsumePostRequest(
-                amount = 1.0
+                amount = amount
+            )
+        ).body()
+    }
+
+    override suspend fun open(productId: Int, amount: Double): Result<List<StockLogEntry>> = runCatching {
+        api.stockProductsProductIdOpenPost(
+            productId = productId,
+            stockProductsProductIdOpenPostRequest = StockProductsProductIdOpenPostRequest(
+                amount = amount
+            )
+        ).body()
+    }
+
+    override suspend fun add(productId: Int, amount: Double): Result<List<StockLogEntry>> = runCatching {
+        api.stockProductsProductIdAddPost(
+            productId = productId,
+            stockProductsProductIdAddPostRequest = StockProductsProductIdAddPostRequest(
+                amount = amount
             )
         ).body()
     }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/stock/StockDataSourceImpl.kt
@@ -2,9 +2,21 @@ package com.srfmolina.krocy.data.datasource.remote.stock
 
 import org.openapitools.client.apis.StockApi
 import org.openapitools.client.models.CurrentStockResponse
+import org.openapitools.client.models.StockLogEntry
+import org.openapitools.client.models.StockProductsProductIdConsumePostRequest
 
-internal class StockDataSourceImpl(private val api: StockApi) : StockDataSource {
+internal class StockDataSourceImpl(private val api: StockApi): StockDataSource {
     override suspend fun getStock(): Result<List<CurrentStockResponse>> = runCatching {
         api.stockGet().body()
     }
+
+    override suspend fun consume(productId: Int): Result<List<StockLogEntry>> = runCatching {
+        api.stockProductsProductIdConsumePost(
+            productId = productId,
+            stockProductsProductIdConsumePostRequest = StockProductsProductIdConsumePostRequest(
+                amount = 1.0
+            )
+        ).body()
+    }
+
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
@@ -35,6 +35,6 @@ val dataModule = module {
     single<GenericEntityDataSource> { GenericEntityDataSourceImpl(get()) }
 
     single<KrocyItemRepository> { KrocyItemRepositoryImpl(get()) }
-    single<StockRepository> { StockRepositoryImpl(get(), get()) }
+    single<StockRepository> { StockRepositoryImpl(get(), get(), baseUrl) }
 
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
@@ -3,6 +3,8 @@ package com.srfmolina.krocy.data.di
 import com.srfmolina.krocy.data.datasource.local.example.KrocyItemDataSource
 import com.srfmolina.krocy.data.datasource.local.example.KrocyItemDataSourceImpl
 import com.srfmolina.krocy.data.datasource.remote.createHttpClient
+import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
+import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSourceImpl
 import com.srfmolina.krocy.data.datasource.remote.stock.StockDataSource
 import com.srfmolina.krocy.data.datasource.remote.stock.StockDataSourceImpl
 import com.srfmolina.krocy.data.db.KrocyDatabase
@@ -13,6 +15,7 @@ import com.srfmolina.krocy.data.repository.impl.StockRepositoryImpl
 import com.srfmolina.krocy.domain.repository.KrocyItemRepository
 import com.srfmolina.krocy.domain.repository.StockRepository
 import org.koin.dsl.module
+import org.openapitools.client.apis.GenericEntityInteractionsApi
 import org.openapitools.client.apis.StockApi
 
 val dataModule = module {
@@ -22,14 +25,16 @@ val dataModule = module {
 
     single { createHttpClient() }
     single { StockApi(baseUrl = baseUrl) }
+    single { GenericEntityInteractionsApi(baseUrl = baseUrl) }
 
     single<KrocyDatabase> { createDatabase() }
     single<KrocyItemDao>  { get<KrocyDatabase>().krocyItemDao() }
 
     single<KrocyItemDataSource> { KrocyItemDataSourceImpl(get()) }
     single<StockDataSource> { StockDataSourceImpl(get()) }
+    single<GenericEntityDataSource> { GenericEntityDataSourceImpl(get()) }
 
     single<KrocyItemRepository> { KrocyItemRepositoryImpl(get()) }
-    single<StockRepository> { StockRepositoryImpl(get()) }
+    single<StockRepository> { StockRepositoryImpl(get(), get()) }
 
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/GrocyPictureUrl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/GrocyPictureUrl.kt
@@ -1,0 +1,24 @@
+package com.srfmolina.krocy.data.mapper
+
+import io.ktor.http.URLBuilder
+import io.ktor.http.appendPathSegments
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Builds the Grocy file-serve URL for a product picture.
+ *
+ * Grocy serves files at `GET /files/{group}/{fileName}` where the file name must be
+ * BASE64-encoded. `appendPathSegments` percent-encodes the base64 (`/`, `+`, `=`), which
+ * Grocy decodes server-side before base64-decoding. `force_serve_as=picture` enables the
+ * `best_fit_width` server-side downscaling.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+internal fun buildProductPictureUrl(baseUrl: String, fileName: String, bestFitWidth: Int = 200): String {
+    val encoded = Base64.encode(fileName.encodeToByteArray())
+    return URLBuilder(baseUrl).apply {
+        appendPathSegments("files", "productpictures", encoded)
+        parameters.append("force_serve_as", "picture")
+        parameters.append("best_fit_width", bestFitWidth.toString())
+    }.buildString()
+}

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
@@ -13,7 +13,7 @@ import kotlin.time.Clock
 
 private val NEVER_EXPIRES = LocalDate(2999, 12, 31)
 
-fun CurrentStockResponse.toDomain(quantityNames: Pair<String, String>): StockItem {
+fun CurrentStockResponse.toDomain(quantityNames: Pair<String, String>, baseUrl: String): StockItem {
     val amount = amount ?: 0.0
     val amountOpened = amountOpened ?: 0.0
     val minStock = product?.minStockAmount ?: 0.0
@@ -37,12 +37,17 @@ fun CurrentStockResponse.toDomain(quantityNames: Pair<String, String>): StockIte
     val (singularName, pluralName) = quantityNames
     val quantityName = if (amount == 1.0) singularName else pluralName
 
+    val pictureUrl = product?.pictureFileName
+        ?.takeIf { it.isNotBlank() }
+        ?.let { buildProductPictureUrl(baseUrl, it) }
+
     return StockItem(
         id = productId ?: 0,
         name = product?.name.orEmpty(),
         hints = hints,
         consumptionDate = consumptionDate,
-        quantity = amount.formatAmount(quantityName)
+        quantity = amount.formatAmount(quantityName),
+        pictureUrl = pictureUrl
     )
 }
 

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/StockMapper.kt
@@ -13,14 +13,14 @@ import kotlin.time.Clock
 
 private val NEVER_EXPIRES = LocalDate(2999, 12, 31)
 
-fun CurrentStockResponse.toDomain(): StockItem {
+fun CurrentStockResponse.toDomain(quantityNames: Pair<String, String>): StockItem {
     val amount = amount ?: 0.0
     val amountOpened = amountOpened ?: 0.0
     val minStock = product?.minStockAmount ?: 0.0
 
     val hints = buildList {
         if (amountOpened > 0) add("${amountOpened.toInt()} abierto")
-        if (minStock > 0 && amount < minStock) add("bajo stock")
+        if (minStock > 0 && amount < minStock) add("bajo stock") //TODO: harcoded text
     }
 
     val consumptionDate = bestBeforeDate
@@ -34,14 +34,17 @@ fun CurrentStockResponse.toDomain(): StockItem {
             )
         }
 
+    val (singularName, pluralName) = quantityNames
+    val quantityName = if (amount == 1.0) singularName else pluralName
+
     return StockItem(
         id = productId ?: 0,
         name = product?.name.orEmpty(),
         hints = hints,
         consumptionDate = consumptionDate,
-        quantity = "${amount.formatAmount()} uds"
+        quantity = amount.formatAmount(quantityName)
     )
 }
 
-private fun Double.formatAmount(): String =
-    if (this % 1.0 == 0.0) this.toInt().toString() else this.toString()
+private fun Double.formatAmount(quantityName: String): String =
+    if (this % 1.0 == 0.0) "${this.toInt()} $quantityName" else "$this $quantityName"

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.sync.withLock
 
 internal class StockRepositoryImpl(
     private val stockDataSource: StockDataSource,
-    private val genericEntityDataSource: GenericEntityDataSource
+    private val genericEntityDataSource: GenericEntityDataSource,
+    private val baseUrl: String
 ) : StockRepository {
 
     private val _cache = MutableStateFlow<List<StockItem>>(emptyList())
@@ -59,7 +60,7 @@ internal class StockRepositoryImpl(
                 }
                 val singularName = quDto?.name ?: "ud"
                 val pluralName = quDto?.namePlural ?: "uds"
-                stockDto.toDomain(quantityNames = Pair(singularName, pluralName))
+                stockDto.toDomain(quantityNames = Pair(singularName, pluralName), baseUrl = baseUrl)
             } } }
         loaded = true
     }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.data.repository.impl
 
+import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
 import com.srfmolina.krocy.data.datasource.remote.stock.StockDataSource
 import com.srfmolina.krocy.data.mapper.toDomain
 import com.srfmolina.krocy.domain.model.stock.StockItem
@@ -12,7 +13,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class StockRepositoryImpl(
-    private val dataSource: StockDataSource
+    private val stockDataSource: StockDataSource,
+    private val genericEntityDataSource: GenericEntityDataSource
 ) : StockRepository {
 
     private val _cache = MutableStateFlow<List<StockItem>>(emptyList())
@@ -28,29 +30,37 @@ internal class StockRepositoryImpl(
         if (loaded) return
         refreshMutex.withLock {
             if (loaded) return
-            refresh()
+            refreshStock()
         }
     }
 
     override suspend fun consume(productId: Int, amount: Int) {
-        dataSource.consume(productId, amount.toDouble()).getOrThrow()
-        refresh()
+        stockDataSource.consume(productId, amount.toDouble()).getOrThrow()
+        refreshStock()
     }
 
     override suspend fun open(productId: Int, amount: Int) {
-        dataSource.open(productId, amount.toDouble()).getOrThrow()
-        refresh()
+        stockDataSource.open(productId, amount.toDouble()).getOrThrow()
+        refreshStock()
     }
 
     override suspend fun add(productId: Int, amount: Int) {
-        dataSource.add(productId, amount.toDouble()).getOrThrow()
-        refresh()
+        stockDataSource.add(productId, amount.toDouble()).getOrThrow()
+        refreshStock()
     }
 
-    private suspend fun refresh() {
-        dataSource.getStock()
+    private suspend fun refreshStock() {
+        val quantityUnitsDtos = genericEntityDataSource.getQuantityUnits().getOrThrow()
+        stockDataSource.getStock()
             .getOrThrow()
-            .also { dtos -> _cache.update { dtos.map { it.toDomain() } } }
+            .also { stockDtos -> _cache.update { stockDtos.map { stockDto ->
+                val quDto = quantityUnitsDtos.firstOrNull { quData ->
+                    quData.id ==  stockDto.product?.quIdStock
+                }
+                val singularName = quDto?.name ?: "ud"
+                val pluralName = quDto?.namePlural ?: "uds"
+                stockDto.toDomain(quantityNames = Pair(singularName, pluralName))
+            } } }
         loaded = true
     }
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -50,6 +50,10 @@ internal class StockRepositoryImpl(
         refreshStock()
     }
 
+    override suspend fun forceRefresh() {
+        refreshStock()
+    }
+
     private suspend fun refreshStock() {
         val quantityUnitsDtos = genericEntityDataSource.getQuantityUnits().getOrThrow()
         stockDataSource.getStock()

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -6,9 +6,10 @@ import com.srfmolina.krocy.domain.model.stock.StockItem
 import com.srfmolina.krocy.domain.repository.StockRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 internal class StockRepositoryImpl(
     private val dataSource: StockDataSource
@@ -16,13 +17,30 @@ internal class StockRepositoryImpl(
 
     private val _cache = MutableStateFlow<List<StockItem>>(emptyList())
 
+    private val refreshMutex = Mutex()
+    private var loaded = false
+
     override fun getStock(): Flow<List<StockItem>> = _cache
-        .asStateFlow()
-        .onSubscription { refresh() }
+        .onSubscription { ensureLoaded() }
+
+    /** Loads the stock once; later subscribers reuse the cached value. */
+    private suspend fun ensureLoaded() {
+        if (loaded) return
+        refreshMutex.withLock {
+            if (loaded) return
+            refresh()
+        }
+    }
+
+    override suspend fun consume(productId: Int) {
+        dataSource.consume(productId).getOrThrow()
+        refresh()
+    }
 
     private suspend fun refresh() {
         dataSource.getStock()
             .getOrThrow()
             .also { dtos -> _cache.update { dtos.map { it.toDomain() } } }
+        loaded = true
     }
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -21,7 +21,7 @@ internal class StockRepositoryImpl(
     private val _cache = MutableStateFlow<List<StockItem>>(emptyList())
 
     private val refreshMutex = Mutex()
-    private var loaded = false
+    @Volatile private var loaded = false
 
     override fun getStock(): Flow<List<StockItem>> = _cache
         .onSubscription { ensureLoaded() }
@@ -37,21 +37,27 @@ internal class StockRepositoryImpl(
 
     override suspend fun consume(productId: Int, amount: Int) {
         stockDataSource.consume(productId, amount.toDouble()).getOrThrow()
-        refreshStock()
+        forceRefreshWithMutex()
     }
 
     override suspend fun open(productId: Int, amount: Int) {
         stockDataSource.open(productId, amount.toDouble()).getOrThrow()
-        refreshStock()
+        forceRefreshWithMutex()
     }
 
     override suspend fun add(productId: Int, amount: Int) {
         stockDataSource.add(productId, amount.toDouble()).getOrThrow()
-        refreshStock()
+        forceRefreshWithMutex()
     }
 
     override suspend fun forceRefresh() {
-        refreshStock()
+        forceRefreshWithMutex()
+    }
+
+    private suspend fun forceRefreshWithMutex() {
+        refreshMutex.withLock {
+            refreshStock()
+        }
     }
 
     private suspend fun refreshStock() {

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/StockRepositoryImpl.kt
@@ -32,8 +32,18 @@ internal class StockRepositoryImpl(
         }
     }
 
-    override suspend fun consume(productId: Int) {
-        dataSource.consume(productId).getOrThrow()
+    override suspend fun consume(productId: Int, amount: Int) {
+        dataSource.consume(productId, amount.toDouble()).getOrThrow()
+        refresh()
+    }
+
+    override suspend fun open(productId: Int, amount: Int) {
+        dataSource.open(productId, amount.toDouble()).getOrThrow()
+        refresh()
+    }
+
+    override suspend fun add(productId: Int, amount: Int) {
+        dataSource.add(productId, amount.toDouble()).getOrThrow()
         refresh()
     }
 

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/stock/StockItem.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/stock/StockItem.kt
@@ -7,5 +7,6 @@ data class StockItem(
     val name: String,
     val hints: List<String>,
     val consumptionDate: ConsumptionDate?,
-    val quantity: String
+    val quantity: String,
+    val pictureUrl: String?
 )

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
@@ -11,4 +11,6 @@ interface StockRepository {
     suspend fun open(productId: Int, amount: Int)
 
     suspend fun add(productId: Int, amount: Int)
+
+    suspend fun forceRefresh()
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
@@ -6,5 +6,9 @@ import kotlinx.coroutines.flow.Flow
 interface StockRepository {
     fun getStock(): Flow<List<StockItem>>
 
-    suspend fun consume(productId: Int)
+    suspend fun consume(productId: Int, amount: Int)
+
+    suspend fun open(productId: Int, amount: Int)
+
+    suspend fun add(productId: Int, amount: Int)
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/StockRepository.kt
@@ -5,4 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface StockRepository {
     fun getStock(): Flow<List<StockItem>>
+
+    suspend fun consume(productId: Int)
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/base/BaseUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/base/BaseUseCase.kt
@@ -41,3 +41,26 @@ abstract class ResultFlowUseCaseNoParams<out R> {
 
     protected abstract fun execute(): Flow<R>
 }
+
+/**
+ * Base class for one-shot (suspend) use cases that return Result<R>.
+ *
+ * - Wraps a successful result in Result.success.
+ * - Explicitly rethrows CancellationException to respect
+ *   structured concurrency.
+ * - Any other throwable is emitted as Result.failure.
+ * - The repository may throw freely; this use case models it.
+ */
+abstract class ResultUseCase<in P, out R> {
+
+    suspend operator fun invoke(params: P): Result<R> =
+        try {
+            Result.success(execute(params))
+        } catch (e: CancellationException) {
+            throw e // nunca swallow cancellation
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+
+    protected abstract suspend fun execute(params: P): R
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/base/BaseUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/base/BaseUseCase.kt
@@ -64,3 +64,17 @@ abstract class ResultUseCase<in P, out R> {
 
     protected abstract suspend fun execute(params: P): R
 }
+
+abstract class ResultUseCaseNoParams<out R> {
+
+    suspend operator fun invoke(): Result<R> =
+        try {
+            Result.success(execute())
+        } catch (e: CancellationException) {
+            throw e // nunca swallow cancellation
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+
+    protected abstract suspend fun execute(): R
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/AddStockUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/AddStockUseCase.kt
@@ -4,9 +4,9 @@ import com.srfmolina.krocy.domain.repository.StockRepository
 import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
 import com.srfmolina.krocy.domain.usecase.stock.model.BasicStockUCRequest
 
-class ConsumeStockUseCase(
+class AddStockUseCase(
     private val repo: StockRepository
 ) : ResultUseCase<BasicStockUCRequest, Unit>() {
 
-    override suspend fun execute(params: BasicStockUCRequest) = repo.consume(params.productId, params.amount)
+    override suspend fun execute(params: BasicStockUCRequest) = repo.add(params.productId, params.amount)
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/ConsumeStockUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/ConsumeStockUseCase.kt
@@ -1,0 +1,11 @@
+package com.srfmolina.krocy.domain.usecase.stock
+
+import com.srfmolina.krocy.domain.repository.StockRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
+
+class ConsumeStockUseCase(
+    private val repo: StockRepository
+) : ResultUseCase<Int, Unit>() {
+
+    override suspend fun execute(params: Int) = repo.consume(params)
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/OpenStockUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/OpenStockUseCase.kt
@@ -4,9 +4,9 @@ import com.srfmolina.krocy.domain.repository.StockRepository
 import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
 import com.srfmolina.krocy.domain.usecase.stock.model.BasicStockUCRequest
 
-class ConsumeStockUseCase(
+class OpenStockUseCase(
     private val repo: StockRepository
 ) : ResultUseCase<BasicStockUCRequest, Unit>() {
 
-    override suspend fun execute(params: BasicStockUCRequest) = repo.consume(params.productId, params.amount)
+    override suspend fun execute(params: BasicStockUCRequest) = repo.open(params.productId, params.amount)
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/RefreshStockUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/RefreshStockUseCase.kt
@@ -1,0 +1,10 @@
+package com.srfmolina.krocy.domain.usecase.stock
+
+import com.srfmolina.krocy.domain.repository.StockRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCaseNoParams
+
+class RefreshStockUseCase(
+    private val repo: StockRepository
+) : ResultUseCaseNoParams<Unit>() {
+    override suspend fun execute() = repo.forceRefresh()
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/model/BasicStockUCRequest.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/stock/model/BasicStockUCRequest.kt
@@ -1,0 +1,6 @@
+package com.srfmolina.krocy.domain.usecase.stock.model
+
+data class BasicStockUCRequest(
+    val productId: Int,
+    val amount: Int
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ ksp     = "2.3.6"
 ktor    = "3.3.3"
 ktorfit = "2.7.2"
 adaptive = "1.2.0"
+coil = "3.2.0"
 
 [libraries]
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
@@ -74,6 +75,8 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktorfit-lib                     = { module = "de.jensklingenberg.ktorfit:ktorfit-lib",            version.ref = "ktorfit" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "adaptive" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt
+++ b/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt
@@ -7,4 +7,7 @@ typealias ExposedEntityIncludingUserEntities = ExposedEntity
 typealias ExposedEntityIncludingUserEntitiesNotIncludingNotEditable = ExposedEntityNoEdit
 typealias ExposedEntityNotIncludingNotDeletable = ExposedEntityNoDelete
 typealias ExposedEntityNotIncludingNotEditable = ExposedEntityNoEdit
-typealias ExposedEntityNotIncludingNotListable = ExposedEntityNoListing
+// The generated ExposedEntityNoListing enum is broken: the Grocy spec only lists `api_keys`
+// under it, so it can't represent listable entities like quantity_units. Point this alias at
+// the full ExposedEntity enum (which has every entity value) so objectsEntityGet can list them.
+typealias ExposedEntityNotIncludingNotListable = ExposedEntity

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -41,6 +41,9 @@ kotlin {
 
             implementation(libs.compose.material3.adaptive)
 
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor3)
+
             implementation(project(":data"))
             implementation(project(":domain"))
         }
@@ -53,11 +56,13 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.koin.android)
+            implementation(libs.ktor.client.okhttp)
         }
 
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutinesSwing)
+            implementation(libs.ktor.client.cio)
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/App.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -11,12 +12,15 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.navOptions
 import com.srfmolina.krocy.ui.AppViewModel.Effect
 import com.srfmolina.krocy.ui.AppViewModel.Event
+import com.srfmolina.krocy.ui.presentation.common.KrocyFabMenu
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.feature.welcome.navigation.navigateToWelcome
 import com.srfmolina.krocy.ui.presentation.navigation.NavigationComponent
 import com.srfmolina.krocy.ui.presentation.navigation.SplashRoute
@@ -25,8 +29,10 @@ import com.srfmolina.krocy.ui.presentation.navigation.component.rail.model.appRa
 import com.srfmolina.krocy.ui.presentation.navigation.component.rail.model.currentRailRoute
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.MediumTopBar
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.SmallTopBar
+import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarTypeUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.spacing
 import kotlinx.coroutines.flow.first
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -74,10 +80,32 @@ fun App() {
                 compactExpanded = state.isNavRailOpen,
                 onCompactDismiss = { viewModel.launchEvent(Event.OnChangeNavRailStatus(false)) },
             ) {
-                MainContent(scrollBehavior, state, viewModel, navControllerState, onOpenNavRail = { viewModel.launchEvent(Event.OnChangeNavRailStatus(true)) })
+                MainContent(
+                    scrollBehavior,
+                    state,
+                    navControllerState,
+                    onOpenNavRail = { viewModel.launchEvent(Event.OnChangeNavRailStatus(true)) },
+                    onChangeTopBar = { config ->
+                        viewModel.launchEvent(Event.OnTopBarChange(config))
+                    },
+                    onChangeFab = { config ->
+                        viewModel.launchEvent(Event.OnFabChange(config))
+                    }
+                )
             }
         } else {
-            MainContent(scrollBehavior, state, viewModel, navControllerState, onOpenNavRail = { viewModel.launchEvent(Event.OnChangeNavRailStatus(true)) })
+            MainContent(
+                scrollBehavior,
+                state,
+                navControllerState,
+                onOpenNavRail = { viewModel.launchEvent(Event.OnChangeNavRailStatus(true)) },
+                onChangeTopBar = { config ->
+                    viewModel.launchEvent(Event.OnTopBarChange(config))
+                },
+                onChangeFab = { config ->
+                    viewModel.launchEvent(Event.OnFabChange(config))
+                }
+            )
         }
     }
 }
@@ -87,9 +115,10 @@ fun App() {
 private fun MainContent(
     scrollBehavior: TopAppBarScrollBehavior?,
     vmState: AppViewModel.State,
-    viewModel: AppViewModel,
     state: AppState,
     onOpenNavRail: () -> Unit,
+    onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize().then(
@@ -127,11 +156,20 @@ private fun MainContent(
         ) {
             NavigationComponent(
                 navController = state.navController,
-                onChangeTopBar = { config ->
-                    viewModel.launchEvent(Event.OnTopBarChange(config))
-                },
+                onChangeTopBar = onChangeTopBar,
+                onChangeFab = onChangeFab,
                 onOpenNavRail = onOpenNavRail
             )
+
+            vmState.fabConfig?.let {
+                KrocyFabMenu(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(MaterialTheme.spacing.s4),
+                    visible = it.isVisible,
+                    actions = it.actions
+                )
+            }
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/AppViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/AppViewModel.kt
@@ -7,6 +7,7 @@ import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
 import com.srfmolina.krocy.ui.base.UiEvent
 import com.srfmolina.krocy.ui.base.UiState
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
 
 internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
@@ -15,6 +16,7 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
         data object Init : Event
         data class OnTopBarChange(val config: TopBarConfigurationUi) : Event
         data class OnChangeNavRailStatus(val open: Boolean) : Event
+        data class OnFabChange(val config: FabConfigurationUi) : Event
     }
 
     sealed interface Effect : UiEffect {
@@ -24,7 +26,8 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
     data class State(
         val isLoading: Boolean = true,
         val isNavRailOpen: Boolean = false,
-        val topBarConfig: TopBarConfigurationUi? = null
+        val topBarConfig: TopBarConfigurationUi? = null,
+        val fabConfig: FabConfigurationUi? = null
     ) : UiState
 
     override fun createInitialState(): State = State()
@@ -34,6 +37,7 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
             is Event.Init -> init()
             is Event.OnTopBarChange -> setState { copy(topBarConfig = event.config) }
             is Event.OnChangeNavRailStatus -> setState { copy(isNavRailOpen = event.open) }
+            is Event.OnFabChange -> setState { copy(fabConfig = event.config) }
         }
     }
 

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
@@ -4,6 +4,7 @@ import com.srfmolina.krocy.domain.usecase.stock.AddStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.OpenStockUseCase
+import com.srfmolina.krocy.domain.usecase.stock.RefreshStockUseCase
 import com.srfmolina.krocy.ui.AppViewModel
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel
 import org.koin.core.module.dsl.singleOf
@@ -15,6 +16,7 @@ val uiModule = module {
     singleOf(::ConsumeStockUseCase)
     singleOf(::AddStockUseCase)
     singleOf(::OpenStockUseCase)
+    singleOf(::RefreshStockUseCase)
 
     viewModelOf(::AppViewModel)
     viewModelOf(::StockViewModel)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
@@ -1,7 +1,9 @@
 package com.srfmolina.krocy.ui.di
 
+import com.srfmolina.krocy.domain.usecase.stock.AddStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
+import com.srfmolina.krocy.domain.usecase.stock.OpenStockUseCase
 import com.srfmolina.krocy.ui.AppViewModel
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel
 import org.koin.core.module.dsl.singleOf
@@ -11,6 +13,8 @@ import org.koin.dsl.module
 val uiModule = module {
     singleOf(::ObserveStockUseCase)
     singleOf(::ConsumeStockUseCase)
+    singleOf(::AddStockUseCase)
+    singleOf(::OpenStockUseCase)
 
     viewModelOf(::AppViewModel)
     viewModelOf(::StockViewModel)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.ui.di
 
+import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
 import com.srfmolina.krocy.ui.AppViewModel
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel
@@ -9,6 +10,7 @@ import org.koin.dsl.module
 
 val uiModule = module {
     singleOf(::ObserveStockUseCase)
+    singleOf(::ConsumeStockUseCase)
 
     viewModelOf(::AppViewModel)
     viewModelOf(::StockViewModel)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyFabMenu.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyFabMenu.kt
@@ -1,0 +1,164 @@
+package com.srfmolina.krocy.ui.presentation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddBox
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleFloatingActionButton
+import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.traversalIndex
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
+import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.spacing
+
+/**
+ * Material 3 Expressive Floating Action Button menu.
+ *
+ * The collapsed FAB shows a `+` icon that morphs into `×` when tapped, revealing a staggered column
+ * of [actions]. Each action is described by a [LabeledActionUi]; tapping one closes the menu and
+ * invokes its `onClick`.
+ *
+ * @param actions the menu entries, rendered top-to-bottom above the toggle button.
+ * @param visible whether the collapsed FAB should be shown. The button stays visible while the menu
+ *   is expanded regardless of this flag (e.g. to keep it on screen while the list is scrolled).
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun KrocyFabMenu(
+    actions: List<LabeledActionUi>,
+    modifier: Modifier = Modifier,
+    visible: Boolean = true,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    FloatingActionButtonMenu(
+        modifier = modifier,
+        expanded = expanded,
+        button = {
+            ToggleFloatingActionButton(
+                modifier = Modifier
+                    .semantics {
+                        traversalIndex = -1f
+                        stateDescription = if (expanded) "Expandido" else "Contraído" // TODO
+                        contentDescription = "Acciones" // TODO
+                    }
+                    .animateFloatingActionButton(
+                        visible = visible || expanded,
+                        alignment = Alignment.BottomEnd
+                    ),
+                checked = expanded,
+                onCheckedChange = { expanded = !expanded }
+            ) {
+                val imageVector by remember {
+                    derivedStateOf {
+                        if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.Add
+                    }
+                }
+                Icon(
+                    painter = rememberVectorPainter(imageVector),
+                    contentDescription = null,
+                    modifier = Modifier.animateIcon({ checkedProgress })
+                )
+            }
+        }
+    ) {
+        actions.forEachIndexed { index, action ->
+            FloatingActionButtonMenuItem(
+                modifier = Modifier.semantics {
+                    isTraversalGroup = true
+                    // The toggle button precedes the items in traversal order, so let the last
+                    // item expose a custom action to close the menu.
+                    if (index == actions.lastIndex) {
+                        customActions = listOf(
+                            CustomAccessibilityAction(
+                                label = "Cerrar menú", // TODO
+                                action = {
+                                    expanded = false
+                                    true
+                                }
+                            )
+                        )
+                    }
+                },
+                onClick = {
+                    expanded = false
+                    action.onClick()
+                },
+                icon = {
+                    action.icon?.let { icon ->
+                        Icon(imageVector = icon, contentDescription = action.contentDescription)
+                    }
+                },
+                text = { Text(action.label) }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@PreviewLightDark
+@Composable
+private fun KrocyFabMenuPreview() {
+    KrocyTheme {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxSize()
+                .padding(MaterialTheme.spacing.s4)
+        ) {
+            KrocyFabMenu(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                actions = listOf(
+                    LabeledActionUi(
+                        label = "Añadir producto",
+                        contentDescription = "Añadir producto",
+                        icon = Icons.Filled.AddBox,
+                        onClick = {}
+                    ),
+                    LabeledActionUi(
+                        label = "Escanear código",
+                        contentDescription = "Escanear código",
+                        icon = Icons.Filled.QrCodeScanner,
+                        onClick = {}
+                    ),
+                    LabeledActionUi(
+                        label = "Compra rápida",
+                        contentDescription = "Compra rápida",
+                        icon = Icons.Filled.ShoppingCart,
+                        onClick = {}
+                    )
+                )
+            )
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/PhotoHolder.kt
@@ -8,16 +8,35 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
+import coil3.compose.AsyncImage
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 
 @Composable
-internal fun PhotoHolder(size: Dp, modifier: Modifier = Modifier, cornerRadius: Dp = MaterialTheme.spacing.s3) {
+internal fun PhotoHolder(
+    size: Dp,
+    modifier: Modifier = Modifier,
+    imageUrl: String? = null,
+    contentDescription: String? = null,
+    cornerRadius: Dp = MaterialTheme.spacing.s3
+) {
     val shape = RoundedCornerShape(cornerRadius)
-    Box(
-        modifier = modifier
-            .size(size)
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh, shape)
-            .border(MaterialTheme.spacing.s0, MaterialTheme.colorScheme.outlineVariant, shape)
-    )
+    val holderModifier = modifier
+        .size(size)
+        .clip(shape)
+        .background(MaterialTheme.colorScheme.surfaceContainerHigh, shape)
+        .border(MaterialTheme.spacing.s0, MaterialTheme.colorScheme.outlineVariant, shape)
+
+    if (imageUrl == null) {
+        Box(holderModifier)
+    } else {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = holderModifier
+        )
+    }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/FabConfigurationUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/FabConfigurationUi.kt
@@ -1,0 +1,6 @@
+package com.srfmolina.krocy.ui.presentation.common.model
+
+internal data class FabConfigurationUi(
+    val isVisible: Boolean,
+    val actions: List<LabeledActionUi>
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/LabeledActionUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/LabeledActionUi.kt
@@ -2,7 +2,7 @@ package com.srfmolina.krocy.ui.presentation.common.model
 
 import androidx.compose.ui.graphics.vector.ImageVector
 
-data class LabeledActionUi(
+internal data class LabeledActionUi(
     val label: String,
     val contentDescription: String,
     val icon: ImageVector? = null,

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonDefaults.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonDefaults.kt
@@ -1,0 +1,42 @@
+package com.srfmolina.krocy.ui.presentation.common.skeleton
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+
+/**
+ * Shared tuning for the skeleton system: the shimmer timing/geometry and the placeholder colours.
+ */
+object SkeletonDefaults {
+
+    /** Default placeholder shape — a pill that reads well for text bars and chips. */
+    val Shape: Shape = RoundedCornerShape(percent = 50)
+
+    /** Duration of one full shimmer sweep across the screen. */
+    const val SweepDurationMillis: Int = 1100
+
+    /**
+     * Distance (px) the highlight band's leading edge travels each sweep, expressed in screen space
+     * so placeholders stay in sync regardless of their position. Sized to comfortably cover a phone
+     * or a desktop column.
+     */
+    const val SweepTravelPx: Float = 1600f
+
+    /** Width (px) of the moving highlight band. */
+    const val BandWidthPx: Float = 360f
+
+    /** Base (dim) colour of a placeholder. Matches [PhotoHolder]'s fill so it blends in. */
+    val baseColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    /** Highlight colour swept across the placeholder by the shimmer band. */
+    val highlightColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceBright
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
@@ -1,0 +1,58 @@
+package com.srfmolina.krocy.ui.presentation.common.skeleton
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+
+/**
+ * Replaces this composable's drawn content with a shimmering skeleton placeholder while the
+ * surrounding [ProvideSkeleton] is active. When inactive, the modifier is a no-op and the real
+ * content draws normally.
+ *
+ * The placeholder is painted over the node's measured bounds using [shape], so the skeleton always
+ * matches the real layout — feed the composable representative dummy data to get believable sizes.
+ * The highlight band is positioned in **screen space**, so every placeholder shares one coherent
+ * diagonal sweep.
+ *
+ * @param shape outline of the placeholder block (defaults to a pill, see [SkeletonDefaults.Shape]).
+ */
+@Composable
+fun Modifier.skeleton(shape: Shape = SkeletonDefaults.Shape): Modifier {
+    val state = LocalSkeletonState.current
+    val progress = state.progress
+    if (!state.isActive || progress == null) return this
+
+    val base = SkeletonDefaults.baseColor
+    val highlight = SkeletonDefaults.highlightColor
+    var windowOffset by remember { mutableStateOf(Offset.Zero) }
+
+    return this
+        .onGloballyPositioned { windowOffset = it.positionInWindow() }
+        .drawWithContent {
+            // Leading edge of the highlight band, in screen space, swept by the shared phase.
+            val head = progress.value * (SkeletonDefaults.SweepTravelPx + SkeletonDefaults.BandWidthPx) -
+                SkeletonDefaults.BandWidthPx
+            // Translate screen space -> this node's local space so all placeholders align.
+            val localX = head - windowOffset.x
+            val localY = -windowOffset.y
+            val brush = Brush.linearGradient(
+                colorStops = arrayOf(0f to base, 0.5f to highlight, 1f to base),
+                // Diagonal band: runs down-right across BandWidthPx in both axes.
+                start = Offset(localX, localY),
+                end = Offset(localX + SkeletonDefaults.BandWidthPx, localY + SkeletonDefaults.BandWidthPx)
+            )
+            val outline = shape.createOutline(size, layoutDirection, this)
+            // Mask the real content (don't call drawContent) and paint the placeholder instead.
+            drawOutline(outline = outline, brush = brush)
+        }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
@@ -27,9 +27,11 @@ import androidx.compose.ui.layout.positionInWindow
  * @param shape outline of the placeholder block (defaults to a pill, see [SkeletonDefaults.Shape]).
  */
 @Composable
-fun Modifier.skeleton(shape: Shape = SkeletonDefaults.Shape): Modifier {
+fun Modifier.skeleton(shape: Shape = SkeletonDefaults.Shape, id: Int? = null): Modifier {
     val state = LocalSkeletonState.current
     val progress = state.progress
+    val targetedLoading = state.targetIds != null
+    if (targetedLoading && !state.targetIds.contains(id)) return this
     if (!state.isActive || progress == null) return this
 
     val base = SkeletonDefaults.baseColor

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonModifier.kt
@@ -30,9 +30,7 @@ import androidx.compose.ui.layout.positionInWindow
 fun Modifier.skeleton(shape: Shape = SkeletonDefaults.Shape, id: Int? = null): Modifier {
     val state = LocalSkeletonState.current
     val progress = state.progress
-    val targetedLoading = state.targetIds != null
-    if (targetedLoading && !state.targetIds.contains(id)) return this
-    if (!state.isActive || progress == null) return this
+    if (!state.targets(id) || progress == null) return this
 
     val base = SkeletonDefaults.baseColor
     val highlight = SkeletonDefaults.highlightColor

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
@@ -24,9 +24,15 @@ import androidx.compose.runtime.staticCompositionLocalOf
 @Immutable
 class SkeletonState(
     val isActive: Boolean,
-    val targetIds: List<Int>? = null,
-    val progress: State<Float>?
-)
+    val progress: State<Float>?,
+    val targetIds: Set<Int>? = null
+) {
+    /**
+     * True when a node identified by [id] should render its skeleton placeholder: the skeleton must
+     * be active, and either untargeted ([targetIds] null = every node) or this [id] is targeted.
+     */
+    fun targets(id: Int?): Boolean = isActive && (targetIds == null || id in targetIds)
+}
 
 val LocalSkeletonState = staticCompositionLocalOf { SkeletonState(isActive = false, progress = null) }
 
@@ -37,7 +43,7 @@ val LocalSkeletonState = staticCompositionLocalOf { SkeletonState(isActive = fal
 @Composable
 fun ProvideSkeleton(
     active: Boolean,
-    targetIds: List<Int>? = null,
+    targetIds: Set<Int>? = null,
     content: @Composable () -> Unit
 ) {
     val skeletonState = if (active) {
@@ -54,7 +60,9 @@ fun ProvideSkeleton(
             ),
             label = "shimmer"
         )
-        remember(progress) { SkeletonState(isActive = true, progress = progress, targetIds = targetIds) }
+        remember(progress, targetIds) {
+            SkeletonState(isActive = true, progress = progress, targetIds = targetIds)
+        }
     } else {
         SkeletonState(isActive = false, progress = null)
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 @Immutable
 class SkeletonState(
     val isActive: Boolean,
+    val targetIds: List<Int>? = null,
     val progress: State<Float>?
 )
 
@@ -36,6 +37,7 @@ val LocalSkeletonState = staticCompositionLocalOf { SkeletonState(isActive = fal
 @Composable
 fun ProvideSkeleton(
     active: Boolean,
+    targetIds: List<Int>? = null,
     content: @Composable () -> Unit
 ) {
     val skeletonState = if (active) {
@@ -52,7 +54,7 @@ fun ProvideSkeleton(
             ),
             label = "shimmer"
         )
-        remember(progress) { SkeletonState(isActive = true, progress = progress) }
+        remember(progress) { SkeletonState(isActive = true, progress = progress, targetIds = targetIds) }
     } else {
         SkeletonState(isActive = false, progress = null)
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonState.kt
@@ -1,0 +1,63 @@
+package com.srfmolina.krocy.ui.presentation.common.skeleton
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Skeleton (loading placeholder) context shared down the composition tree.
+ *
+ * While [isActive] is true, any composable tagged with [Modifier.skeleton][skeleton] paints a
+ * shimmering placeholder instead of its real content. [progress] is the shared shimmer phase
+ * (0f..1f, looping) so every placeholder on screen sweeps in sync — it is read in the draw phase,
+ * never in composition, to keep the animation off the recomposition path.
+ */
+@Immutable
+class SkeletonState(
+    val isActive: Boolean,
+    val progress: State<Float>?
+)
+
+val LocalSkeletonState = staticCompositionLocalOf { SkeletonState(isActive = false, progress = null) }
+
+/**
+ * Provides a [SkeletonState] to [content]. When [active], starts a single looping shimmer animation
+ * shared by every descendant placeholder; when inactive, no animation is running.
+ */
+@Composable
+fun ProvideSkeleton(
+    active: Boolean,
+    content: @Composable () -> Unit
+) {
+    val skeletonState = if (active) {
+        val transition = rememberInfiniteTransition(label = "skeleton")
+        val progress = transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = SkeletonDefaults.SweepDurationMillis,
+                    easing = LinearEasing
+                ),
+                repeatMode = RepeatMode.Restart
+            ),
+            label = "shimmer"
+        )
+        remember(progress) { SkeletonState(isActive = true, progress = progress) }
+    } else {
+        SkeletonState(isActive = false, progress = null)
+    }
+
+    CompositionLocalProvider(LocalSkeletonState provides skeletonState) {
+        content()
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonTransitionAnimation.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/skeleton/SkeletonTransitionAnimation.kt
@@ -1,0 +1,30 @@
+package com.srfmolina.krocy.ui.presentation.common.skeleton
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SkeletonTransitionAnimation(
+    isLoading: Boolean,
+    content: @Composable (Boolean) -> Unit
+) {
+    val motionScheme = MaterialTheme.motionScheme
+    AnimatedContent(
+        targetState = isLoading,
+        transitionSpec = {
+            (fadeIn(motionScheme.defaultEffectsSpec()) togetherWith
+                    fadeOut(motionScheme.defaultEffectsSpec()))
+                .using(SizeTransform(clip = false) { _, _ -> motionScheme.defaultSpatialSpec() })
+        },
+        label = "loading"
+    ) { loading ->
+        content(loading)
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -1,7 +1,6 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -22,13 +21,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
-import com.srfmolina.krocy.ui.presentation.common.KrocyFabMenu
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
 import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
 import com.srfmolina.krocy.ui.presentation.common.skeleton.ProvideSkeleton
@@ -47,10 +45,17 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 internal fun StockScreen(
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
     onOpenNavRail: () -> Unit
 ) {
     val viewModel: StockViewModel = koinViewModel()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+    val fabVisible by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex == 0 || !listState.canScrollForward
+        }
+    }
 
     LaunchedEffect(Unit) {
         onChangeTopBar(TopBarConfigurationUi(
@@ -65,14 +70,28 @@ internal fun StockScreen(
         viewModel.launchEvent(Event.Init)
     }
 
+    LaunchedEffect(state.isLoading, fabVisible) {
+        onChangeFab(FabConfigurationUi(
+            isVisible = !state.isLoading && fabVisible,
+            actions = listOf(
+                LabeledActionUi(
+                    label = "Actualizar",
+                    contentDescription = "Acción de refrescar datos",
+                    icon = Icons.Default.Refresh,
+                    onClick = { viewModel.launchEvent(Event.OnRefresh) }
+                )
+            )
+        ))
+    }
+
     StockScreen(
         isLoading = state.isLoading,
         loadingItemIds = state.loadingItemIds,
+        listState = listState,
         items = state.items,
         onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
         onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
         onOpen = { productId -> viewModel.launchEvent(Event.OnOpenOne(productId)) },
-        onRefresh = { viewModel.launchEvent(Event.OnRefresh) }
     )
 }
 
@@ -81,55 +100,31 @@ internal fun StockScreen(
 private fun StockScreen(
     isLoading: Boolean,
     loadingItemIds: Set<Int>,
+    listState: LazyListState,
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
     onOpen: (Int) -> Unit,
-    onRefresh: () -> Unit
 ) {
-    val listState = rememberLazyListState()
-    val fabVisible by remember {
-        derivedStateOf {
-            listState.firstVisibleItemIndex == 0 || !listState.canScrollForward
-        }
-    }
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        SkeletonTransitionAnimation(
-            isLoading = isLoading
-        ) { loading ->
-            if (loading) {
-                ProvideSkeleton(active = true) {
-                    StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
-                }
-            } else {
-                ProvideSkeleton(active = loadingItemIds.isNotEmpty(), targetIds = loadingItemIds) {
-                    StockList(
-                        items = items,
-                        listState = listState,
-                        contentPadding = PaddingValues(bottom = MaterialTheme.spacing.s28),
-                        onConsume = onConsume,
-                        onAdd = onAdd,
-                        onOpen = onOpen
-                    )
-                }
+    SkeletonTransitionAnimation(
+        isLoading = isLoading
+    ) { loading ->
+        if (loading) {
+            ProvideSkeleton(active = true) {
+                StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
+            }
+        } else {
+            ProvideSkeleton(active = loadingItemIds.isNotEmpty(), targetIds = loadingItemIds) {
+                StockList(
+                    items = items,
+                    listState = listState,
+                    contentPadding = PaddingValues(bottom = MaterialTheme.spacing.s28),
+                    onConsume = onConsume,
+                    onAdd = onAdd,
+                    onOpen = onOpen
+                )
             }
         }
-
-        KrocyFabMenu(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(MaterialTheme.spacing.s4),
-            visible = !isLoading && fabVisible,
-            actions = listOf(
-                LabeledActionUi(
-                    label = "Actualizar",
-                    contentDescription = "Acción de refrescar datos",
-                    icon = Icons.Default.Refresh,
-                    onClick = onRefresh
-                )
-            )
-        )
     }
 }
 
@@ -206,7 +201,6 @@ private fun StockScreenPreview() {
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
-                onRefresh = {},
                 items = List(15) {
                     StockItemUi(
                         id = (1..1000).random(),
@@ -246,7 +240,8 @@ private fun StockScreenPreview() {
                         quantity = "3 Packs",
                         pictureUrl = null
                     )
-                }
+                },
+                listState = rememberLazyListState()
             )
         }
     }
@@ -263,8 +258,8 @@ private fun StockScreenSkeletonPreview() {
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
-                onRefresh = {},
-                items = emptyList()
+                items = emptyList(),
+                listState = rememberLazyListState()
             )
         }
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -204,13 +204,13 @@ private fun StockList(
  * hint counts and an expiry chip), so the placeholder matches the real list's shape.
  */
 private val skeletonPlaceholders: List<StockItemUi> = listOf(
-    StockItemUi(0, "Galletas María", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 2 días", false), "3 Packs"),
-    StockItemUi(1, "Yogur natural", listOf("8 unidades", "2 abiertos"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", false), "3 uds"),
-    StockItemUi(2, "Leche entera", listOf("3 briks"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", true), "2 uds"),
-    StockItemUi(3, "Pan de molde", emptyList(), null, "1 paquete"),
-    StockItemUi(4, "Queso curado", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", false), "250 g"),
-    StockItemUi(5, "Huevos camperos", listOf("6 unidades"), null, "1 docena"),
-    StockItemUi(6, "Mantequilla", emptyList(), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 5 días", false), "1 ud"),
+    StockItemUi(0, "Galletas María", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 2 días", false), "3 Packs", null),
+    StockItemUi(1, "Yogur natural", listOf("8 unidades", "2 abiertos"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", false), "3 uds", null),
+    StockItemUi(2, "Leche entera", listOf("3 briks"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", true), "2 uds", null),
+    StockItemUi(3, "Pan de molde", emptyList(), null, "1 paquete", null),
+    StockItemUi(4, "Queso curado", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", false), "250 g", null),
+    StockItemUi(5, "Huevos camperos", listOf("6 unidades"), null, "1 docena", null),
+    StockItemUi(6, "Mantequilla", emptyList(), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 5 días", false), "1 ud", null),
 )
 
 @PreviewLightDark
@@ -260,7 +260,8 @@ private fun StockScreenPreview() {
                         } else {
                             null
                         },
-                        quantity = "3 Packs"
+                        quantity = "3 Packs",
+                        pictureUrl = null
                     )
                 }
             )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -1,26 +1,38 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddBox
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
+import com.srfmolina.krocy.ui.presentation.common.KrocyFabMenu
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
 import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
+import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
 import com.srfmolina.krocy.ui.presentation.common.skeleton.ProvideSkeleton
 import com.srfmolina.krocy.ui.presentation.common.skeleton.SkeletonTransitionAnimation
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel.Event
@@ -75,31 +87,84 @@ private fun StockScreen(
     onAdd: (Int) -> Unit,
     onOpen: (Int) -> Unit
 ) {
-    SkeletonTransitionAnimation(
-        isLoading = isLoading
-    ) { loading ->
-        if (loading) {
-            ProvideSkeleton(active = true) {
-                StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
-            }
-        } else {
-            ProvideSkeleton(active = loadingItemIds.isNotEmpty(), targetIds = loadingItemIds) {
-                StockList(items = items, onConsume = onConsume, onAdd = onAdd, onOpen = onOpen)
-            }
+    val listState = rememberLazyListState()
+    val fabVisible by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex == 0 || !listState.canScrollForward
         }
     }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        SkeletonTransitionAnimation(
+            isLoading = isLoading
+        ) { loading ->
+            if (loading) {
+                ProvideSkeleton(active = true) {
+                    StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
+                }
+            } else {
+                ProvideSkeleton(active = loadingItemIds.isNotEmpty(), targetIds = loadingItemIds) {
+                    StockList(
+                        items = items,
+                        listState = listState,
+                        contentPadding = PaddingValues(bottom = MaterialTheme.spacing.s28),
+                        onConsume = onConsume,
+                        onAdd = onAdd,
+                        onOpen = onOpen
+                    )
+                }
+            }
+        }
+
+        KrocyFabMenu(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(MaterialTheme.spacing.s4),
+            visible = !isLoading && fabVisible,
+            actions = stockFabActions()
+        )
+    }
 }
+
+/**
+ * Placeholder actions for the stock FAB menu. The real stock actions are not implemented yet, so
+ * these are wired as no-ops; once available they become [StockViewModel.Event]s forwarded here.
+ */
+private fun stockFabActions(): List<LabeledActionUi> = listOf(
+    LabeledActionUi(
+        label = "Añadir producto", // TODO
+        contentDescription = "Añadir producto", // TODO
+        icon = Icons.Filled.AddBox,
+        onClick = {}
+    ),
+    LabeledActionUi(
+        label = "Escanear código", // TODO
+        contentDescription = "Escanear código", // TODO
+        icon = Icons.Filled.QrCodeScanner,
+        onClick = {}
+    ),
+    LabeledActionUi(
+        label = "Compra rápida", // TODO
+        contentDescription = "Compra rápida", // TODO
+        icon = Icons.Filled.ShoppingCart,
+        onClick = {}
+    )
+)
 
 @Composable
 private fun StockList(
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
-    onOpen: (Int) -> Unit
+    onOpen: (Int) -> Unit,
+    listState: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues()
 ) {
     if (MaterialTheme.isCompact) {
         LazyColumn(
+            state = listState,
             modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.s4),
+            contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s3)
         ) {
             items(items) { item ->
@@ -113,7 +178,11 @@ private fun StockList(
             }
         }
     } else {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding
+        ) {
             itemsIndexed(items) { index, item ->
                 StockItemComp(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -52,12 +52,18 @@ internal fun StockScreen(
         viewModel.launchEvent(Event.Init)
     }
 
-    StockScreen(items = state.items)
+    StockScreen(
+        items = state.items,
+        onConsume = { productId ->
+            viewModel.launchEvent(Event.OnConsume(productId))
+        }
+    )
 }
 
 @Composable
 private fun StockScreen(
-    items: List<StockItemUi>
+    items: List<StockItemUi>,
+    onConsume: (Int) -> Unit
 ) {
     if (MaterialTheme.isCompact) {
         LazyColumn(
@@ -67,7 +73,8 @@ private fun StockScreen(
             items(items) { item ->
                 StockItemComp(
                     modifier = Modifier.padding(MaterialTheme.spacing.s3),
-                    item = item
+                    item = item,
+                    onConsume = onConsume
                 )
             }
         }
@@ -76,7 +83,8 @@ private fun StockScreen(
             itemsIndexed(items) { index, item ->
                 StockItemComp(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),
-                    item = item
+                    item = item,
+                    onConsume = onConsume
                 )
                 if (index < items.lastIndex) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -92,7 +100,8 @@ private fun StockScreenPreview() {
     KrocyTheme {
         Surface {
             StockScreen(
-                List(15) {
+                onConsume = {},
+                items = List(15) {
                     StockItemUi(
                         id = (1..1000).random(),
                         name = listOf("Apple", "Banana", "Milk", "Bread", "Cheese", "Eggs", "Butter").random(),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -54,16 +54,18 @@ internal fun StockScreen(
 
     StockScreen(
         items = state.items,
-        onConsume = { productId ->
-            viewModel.launchEvent(Event.OnConsume(productId))
-        }
+        onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
+        onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
+        onOpen = { productId -> viewModel.launchEvent(Event.OnOpenOne(productId)) }
     )
 }
 
 @Composable
 private fun StockScreen(
     items: List<StockItemUi>,
-    onConsume: (Int) -> Unit
+    onConsume: (Int) -> Unit,
+    onAdd: (Int) -> Unit,
+    onOpen: (Int) -> Unit
 ) {
     if (MaterialTheme.isCompact) {
         LazyColumn(
@@ -74,7 +76,9 @@ private fun StockScreen(
                 StockItemComp(
                     modifier = Modifier.padding(MaterialTheme.spacing.s3),
                     item = item,
-                    onConsume = onConsume
+                    onConsume = onConsume,
+                    onAdd = onAdd,
+                    onOpen = onOpen
                 )
             }
         }
@@ -84,7 +88,9 @@ private fun StockScreen(
                 StockItemComp(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),
                     item = item,
-                    onConsume = onConsume
+                    onConsume = onConsume,
+                    onAdd = onAdd,
+                    onOpen = onOpen
                 )
                 if (index < items.lastIndex) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -101,17 +107,39 @@ private fun StockScreenPreview() {
         Surface {
             StockScreen(
                 onConsume = {},
+                onAdd = {},
+                onOpen = {},
                 items = List(15) {
                     StockItemUi(
                         id = (1..1000).random(),
-                        name = listOf("Apple", "Banana", "Milk", "Bread", "Cheese", "Eggs", "Butter").random(),
+                        name = listOf(
+                            "Apple",
+                            "Banana",
+                            "Milk",
+                            "Bread",
+                            "Cheese",
+                            "Eggs",
+                            "Butter"
+                        ).random(),
                         hints = List((2..8).random()) {
-                            listOf("fresh", "organic", "frozen", "imported", "local", "gluten-free").random()
+                            listOf(
+                                "fresh",
+                                "organic",
+                                "frozen",
+                                "imported",
+                                "local",
+                                "gluten-free"
+                            ).random()
                         },
                         consumptionDate = if (listOf(true, false).random()) {
                             ConsumptionDateUi(
                                 type = ConsumptionType.entries.random(),
-                                date = listOf("En 2 días", "Hace 1 semana", "En 4 días", "Hace 2 días").random(),
+                                date = listOf(
+                                    "En 2 días",
+                                    "Hace 1 semana",
+                                    "En 4 días",
+                                    "Hace 2 días"
+                                ).random(),
                                 expired = listOf(true, false).random()
                             )
                         } else {

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -57,7 +57,7 @@ internal fun StockScreen(
 
     StockScreen(
         isLoading = state.isLoading,
-        isLoadingItem = state.isLoadingItem,
+        loadingItemIds = state.loadingItemIds,
         items = state.items,
         onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
         onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
@@ -69,7 +69,7 @@ internal fun StockScreen(
 @Composable
 private fun StockScreen(
     isLoading: Boolean,
-    isLoadingItem: Int?,
+    loadingItemIds: Set<Int>,
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
@@ -83,7 +83,7 @@ private fun StockScreen(
                 StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
             }
         } else {
-            ProvideSkeleton(active = isLoadingItem != null, targetIds = isLoadingItem?.let {listOf(isLoadingItem)}) {
+            ProvideSkeleton(active = loadingItemIds.isNotEmpty(), targetIds = loadingItemIds) {
                 StockList(items = items, onConsume = onConsume, onAdd = onAdd, onOpen = onOpen)
             }
         }
@@ -151,7 +151,7 @@ private fun StockScreenPreview() {
         Surface {
             StockScreen(
                 isLoading = false,
-                isLoadingItem = null,
+                loadingItemIds = emptySet(),
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
@@ -206,7 +206,7 @@ private fun StockScreenSkeletonPreview() {
         Surface {
             StockScreen(
                 isLoading = true,
-                isLoadingItem = null,
+                loadingItemIds = emptySet(),
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -11,10 +11,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AddBox
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.QrCodeScanner
-import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -73,7 +71,8 @@ internal fun StockScreen(
         items = state.items,
         onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
         onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
-        onOpen = { productId -> viewModel.launchEvent(Event.OnOpenOne(productId)) }
+        onOpen = { productId -> viewModel.launchEvent(Event.OnOpenOne(productId)) },
+        onRefresh = { viewModel.launchEvent(Event.OnRefresh) }
     )
 }
 
@@ -85,7 +84,8 @@ private fun StockScreen(
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
-    onOpen: (Int) -> Unit
+    onOpen: (Int) -> Unit,
+    onRefresh: () -> Unit
 ) {
     val listState = rememberLazyListState()
     val fabVisible by remember {
@@ -121,35 +121,17 @@ private fun StockScreen(
                 .align(Alignment.BottomEnd)
                 .padding(MaterialTheme.spacing.s4),
             visible = !isLoading && fabVisible,
-            actions = stockFabActions()
+            actions = listOf(
+                LabeledActionUi(
+                    label = "Actualizar",
+                    contentDescription = "Acción de refrescar datos",
+                    icon = Icons.Default.Refresh,
+                    onClick = onRefresh
+                )
+            )
         )
     }
 }
-
-/**
- * Placeholder actions for the stock FAB menu. The real stock actions are not implemented yet, so
- * these are wired as no-ops; once available they become [StockViewModel.Event]s forwarded here.
- */
-private fun stockFabActions(): List<LabeledActionUi> = listOf(
-    LabeledActionUi(
-        label = "Añadir producto", // TODO
-        contentDescription = "Añadir producto", // TODO
-        icon = Icons.Filled.AddBox,
-        onClick = {}
-    ),
-    LabeledActionUi(
-        label = "Escanear código", // TODO
-        contentDescription = "Escanear código", // TODO
-        icon = Icons.Filled.QrCodeScanner,
-        onClick = {}
-    ),
-    LabeledActionUi(
-        label = "Compra rápida", // TODO
-        contentDescription = "Compra rápida", // TODO
-        icon = Icons.Filled.ShoppingCart,
-        onClick = {}
-    )
-)
 
 @Composable
 private fun StockList(
@@ -224,6 +206,7 @@ private fun StockScreenPreview() {
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
+                onRefresh = {},
                 items = List(15) {
                     StockItemUi(
                         id = (1..1000).random(),
@@ -280,6 +263,7 @@ private fun StockScreenSkeletonPreview() {
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
+                onRefresh = {},
                 items = emptyList()
             )
         }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -57,6 +57,7 @@ internal fun StockScreen(
 
     StockScreen(
         isLoading = state.isLoading,
+        isLoadingItem = state.isLoadingItem,
         items = state.items,
         onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
         onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
@@ -68,6 +69,7 @@ internal fun StockScreen(
 @Composable
 private fun StockScreen(
     isLoading: Boolean,
+    isLoadingItem: Int?,
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
@@ -81,7 +83,9 @@ private fun StockScreen(
                 StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
             }
         } else {
-            StockList(items = items, onConsume = onConsume, onAdd = onAdd, onOpen = onOpen)
+            ProvideSkeleton(active = isLoadingItem != null, targetIds = isLoadingItem?.let {listOf(isLoadingItem)}) {
+                StockList(items = items, onConsume = onConsume, onAdd = onAdd, onOpen = onOpen)
+            }
         }
     }
 }
@@ -147,6 +151,7 @@ private fun StockScreenPreview() {
         Surface {
             StockScreen(
                 isLoading = false,
+                isLoadingItem = null,
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
@@ -201,6 +206,7 @@ private fun StockScreenSkeletonPreview() {
         Surface {
             StockScreen(
                 isLoading = true,
+                isLoadingItem = null,
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -20,6 +21,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.common.ConsumptionType
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
 import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
+import com.srfmolina.krocy.ui.presentation.common.skeleton.ProvideSkeleton
+import com.srfmolina.krocy.ui.presentation.common.skeleton.SkeletonTransitionAnimation
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel.Event
 import com.srfmolina.krocy.ui.presentation.feature.stock.component.StockItemComp
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
@@ -53,6 +56,7 @@ internal fun StockScreen(
     }
 
     StockScreen(
+        isLoading = state.isLoading,
         items = state.items,
         onConsume = { productId -> viewModel.launchEvent(Event.OnConsumeOne(productId)) },
         onAdd = { productId -> viewModel.launchEvent(Event.OnAddOne(productId)) },
@@ -60,8 +64,30 @@ internal fun StockScreen(
     )
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun StockScreen(
+    isLoading: Boolean,
+    items: List<StockItemUi>,
+    onConsume: (Int) -> Unit,
+    onAdd: (Int) -> Unit,
+    onOpen: (Int) -> Unit
+) {
+    SkeletonTransitionAnimation(
+        isLoading = isLoading
+    ) { loading ->
+        if (loading) {
+            ProvideSkeleton(active = true) {
+                StockList(items = skeletonPlaceholders, onConsume = {}, onAdd = {}, onOpen = {})
+            }
+        } else {
+            StockList(items = items, onConsume = onConsume, onAdd = onAdd, onOpen = onOpen)
+        }
+    }
+}
+
+@Composable
+private fun StockList(
     items: List<StockItemUi>,
     onConsume: (Int) -> Unit,
     onAdd: (Int) -> Unit,
@@ -100,12 +126,27 @@ private fun StockScreen(
     }
 }
 
+/**
+ * Representative dummy items used only to drive the loading skeleton's layout (varied name lengths,
+ * hint counts and an expiry chip), so the placeholder matches the real list's shape.
+ */
+private val skeletonPlaceholders: List<StockItemUi> = listOf(
+    StockItemUi(0, "Galletas María", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 2 días", false), "3 Packs"),
+    StockItemUi(1, "Yogur natural", listOf("8 unidades", "2 abiertos"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", false), "3 uds"),
+    StockItemUi(2, "Leche entera", listOf("3 briks"), ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", true), "2 uds"),
+    StockItemUi(3, "Pan de molde", emptyList(), null, "1 paquete"),
+    StockItemUi(4, "Queso curado", listOf("1 abierto"), ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", false), "250 g"),
+    StockItemUi(5, "Huevos camperos", listOf("6 unidades"), null, "1 docena"),
+    StockItemUi(6, "Mantequilla", emptyList(), ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 5 días", false), "1 ud"),
+)
+
 @PreviewLightDark
 @Composable
 private fun StockScreenPreview() {
     KrocyTheme {
         Surface {
             StockScreen(
+                isLoading = false,
                 onConsume = {},
                 onAdd = {},
                 onOpen = {},
@@ -148,6 +189,22 @@ private fun StockScreenPreview() {
                         quantity = "3 Packs"
                     )
                 }
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun StockScreenSkeletonPreview() {
+    KrocyTheme {
+        Surface {
+            StockScreen(
+                isLoading = true,
+                onConsume = {},
+                onAdd = {},
+                onOpen = {},
+                items = emptyList()
             )
         }
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
@@ -1,6 +1,7 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock
 
 import androidx.lifecycle.viewModelScope
+import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
 import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
@@ -15,11 +16,13 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 internal class StockViewModel(
-    private val observeStockUseCase: ObserveStockUseCase
+    private val observeStockUseCase: ObserveStockUseCase,
+    private val consumeStockUseCase: ConsumeStockUseCase
 ) : BaseViewModel<Event, State, Effect>() {
 
     sealed interface Event : UiEvent {
         data object Init : Event
+        data class OnConsume(val productId: Int) : Event
     }
 
     sealed interface Effect : UiEffect
@@ -34,6 +37,7 @@ internal class StockViewModel(
     override suspend fun handleEvent(event: Event) {
         when (event) {
             is Event.Init -> init()
+            is Event.OnConsume -> consume(event.productId)
         }
     }
 
@@ -48,4 +52,8 @@ internal class StockViewModel(
             setState { copy(isLoading = false) }
         }
     }.launchIn(viewModelScope)
+
+    private suspend fun consume(productId: Int) {
+        consumeStockUseCase(productId)  //TODO: consume loading animation
+    }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
@@ -36,6 +36,7 @@ internal class StockViewModel(
 
     data class State(
         val isLoading: Boolean = true,
+        val isLoadingItem: Int? = null,
         val items: List<StockItemUi> = emptyList()
     ) : UiState
 
@@ -56,21 +57,24 @@ internal class StockViewModel(
 
     private fun getStock() = observeStockUseCase().onEach { result ->
         result.onSuccess { items ->
-            setState { copy(isLoading = false, items = items.map { it.toUi() }) }
+            setState { copy(isLoading = false, isLoadingItem = null, items = items.map { it.toUi() }) }
         }.onFailure {
-            setState { copy(isLoading = false) }
+            setState { copy(isLoading = false, isLoadingItem = null) }
         }
     }.launchIn(viewModelScope)
 
     private suspend fun consume(productId: Int, amount: Int) {
+        setState { copy(isLoadingItem = productId) }
         consumeStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: consume loading animation
     }
 
     private suspend fun add(productId: Int, amount: Int) {
+        setState { copy(isLoadingItem = productId) }
         addStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: add loading animation
     }
 
     private suspend fun open(productId: Int, amount: Int) {
+        setState { copy(isLoadingItem = productId) }
         openStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: open loading animation
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
@@ -36,7 +36,7 @@ internal class StockViewModel(
 
     data class State(
         val isLoading: Boolean = true,
-        val isLoadingItem: Int? = null,
+        val loadingItemIds: Set<Int> = emptySet(),
         val items: List<StockItemUi> = emptyList()
     ) : UiState
 
@@ -57,24 +57,30 @@ internal class StockViewModel(
 
     private fun getStock() = observeStockUseCase().onEach { result ->
         result.onSuccess { items ->
-            setState { copy(isLoading = false, isLoadingItem = null, items = items.map { it.toUi() }) }
+            setState { copy(isLoading = false, items = items.map { it.toUi() }) }
         }.onFailure {
-            setState { copy(isLoading = false, isLoadingItem = null) }
+            setState { copy(isLoading = false) }
         }
     }.launchIn(viewModelScope)
 
     private suspend fun consume(productId: Int, amount: Int) {
-        setState { copy(isLoadingItem = productId) }
-        consumeStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: consume loading animation
+        setState { copy(loadingItemIds = loadingItemIds + productId) }
+        val result = consumeStockUseCase(BasicStockUCRequest(productId, amount))
+        setState { copy(loadingItemIds = loadingItemIds - productId) }
+        result.onFailure { /* TODO: surface error effect */ }
     }
 
     private suspend fun add(productId: Int, amount: Int) {
-        setState { copy(isLoadingItem = productId) }
-        addStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: add loading animation
+        setState { copy(loadingItemIds = loadingItemIds + productId) }
+        val result = addStockUseCase(BasicStockUCRequest(productId, amount))
+        setState { copy(loadingItemIds = loadingItemIds - productId) }
+        result.onFailure { /* TODO: surface error effect */ }
     }
 
     private suspend fun open(productId: Int, amount: Int) {
-        setState { copy(isLoadingItem = productId) }
-        openStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: open loading animation
+        setState { copy(loadingItemIds = loadingItemIds + productId) }
+        val result = openStockUseCase(BasicStockUCRequest(productId, amount))
+        setState { copy(loadingItemIds = loadingItemIds - productId) }
+        result.onFailure { /* TODO: surface error effect */ }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
@@ -1,8 +1,11 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock
 
 import androidx.lifecycle.viewModelScope
+import com.srfmolina.krocy.domain.usecase.stock.AddStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
+import com.srfmolina.krocy.domain.usecase.stock.OpenStockUseCase
+import com.srfmolina.krocy.domain.usecase.stock.model.BasicStockUCRequest
 import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
 import com.srfmolina.krocy.ui.base.UiEvent
@@ -17,12 +20,16 @@ import kotlinx.coroutines.flow.onEach
 
 internal class StockViewModel(
     private val observeStockUseCase: ObserveStockUseCase,
-    private val consumeStockUseCase: ConsumeStockUseCase
+    private val consumeStockUseCase: ConsumeStockUseCase,
+    private val addStockUseCase: AddStockUseCase,
+    private val openStockUseCase: OpenStockUseCase
 ) : BaseViewModel<Event, State, Effect>() {
 
     sealed interface Event : UiEvent {
         data object Init : Event
-        data class OnConsume(val productId: Int) : Event
+        data class OnConsumeOne(val productId: Int) : Event
+        data class OnOpenOne(val productId: Int) : Event
+        data class OnAddOne(val productId: Int) : Event
     }
 
     sealed interface Effect : UiEffect
@@ -37,7 +44,9 @@ internal class StockViewModel(
     override suspend fun handleEvent(event: Event) {
         when (event) {
             is Event.Init -> init()
-            is Event.OnConsume -> consume(event.productId)
+            is Event.OnConsumeOne -> consume(event.productId, 1)
+            is Event.OnAddOne -> add(event.productId, 1)
+            is Event.OnOpenOne -> open(event.productId, 1)
         }
     }
 
@@ -53,7 +62,15 @@ internal class StockViewModel(
         }
     }.launchIn(viewModelScope)
 
-    private suspend fun consume(productId: Int) {
-        consumeStockUseCase(productId)  //TODO: consume loading animation
+    private suspend fun consume(productId: Int, amount: Int) {
+        consumeStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: consume loading animation
+    }
+
+    private suspend fun add(productId: Int, amount: Int) {
+        addStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: add loading animation
+    }
+
+    private suspend fun open(productId: Int, amount: Int) {
+        openStockUseCase(BasicStockUCRequest(productId, amount))  //TODO: open loading animation
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/StockViewModel.kt
@@ -5,6 +5,7 @@ import com.srfmolina.krocy.domain.usecase.stock.AddStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.OpenStockUseCase
+import com.srfmolina.krocy.domain.usecase.stock.RefreshStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.model.BasicStockUCRequest
 import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
@@ -22,11 +23,13 @@ internal class StockViewModel(
     private val observeStockUseCase: ObserveStockUseCase,
     private val consumeStockUseCase: ConsumeStockUseCase,
     private val addStockUseCase: AddStockUseCase,
-    private val openStockUseCase: OpenStockUseCase
+    private val openStockUseCase: OpenStockUseCase,
+    private val refreshStockUseCase: RefreshStockUseCase
 ) : BaseViewModel<Event, State, Effect>() {
 
     sealed interface Event : UiEvent {
         data object Init : Event
+        data object OnRefresh : Event
         data class OnConsumeOne(val productId: Int) : Event
         data class OnOpenOne(val productId: Int) : Event
         data class OnAddOne(val productId: Int) : Event
@@ -48,6 +51,7 @@ internal class StockViewModel(
             is Event.OnConsumeOne -> consume(event.productId, 1)
             is Event.OnAddOne -> add(event.productId, 1)
             is Event.OnOpenOne -> open(event.productId, 1)
+            is Event.OnRefresh -> refresh()
         }
     }
 
@@ -82,5 +86,11 @@ internal class StockViewModel(
         val result = openStockUseCase(BasicStockUCRequest(productId, amount))
         setState { copy(loadingItemIds = loadingItemIds - productId) }
         result.onFailure { /* TODO: surface error effect */ }
+    }
+
+    private suspend fun refresh() {
+        setState { copy(isLoading = true) }
+        refreshStockUseCase()
+        setState { copy(isLoading = false) }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -1,12 +1,16 @@
 package com.srfmolina.krocy.ui.presentation.feature.stock.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddBox
 import androidx.compose.material.icons.filled.Drafts
@@ -30,6 +34,9 @@ import com.srfmolina.krocy.ui.presentation.common.PhotoHolder
 import com.srfmolina.krocy.ui.presentation.common.TheeDotsMenuButton
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
 import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
+import com.srfmolina.krocy.ui.presentation.common.skeleton.LocalSkeletonState
+import com.srfmolina.krocy.ui.presentation.common.skeleton.ProvideSkeleton
+import com.srfmolina.krocy.ui.presentation.common.skeleton.skeleton
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
 import com.srfmolina.krocy.ui.presentation.theme.extendedColorScheme
@@ -86,7 +93,10 @@ private fun StockItemCompact(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
         ) {
-            PhotoHolder(size = MaterialTheme.spacing.s18) //TODO
+            PhotoHolder(
+                size = MaterialTheme.spacing.s18,
+                modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3))
+            ) //TODO
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
@@ -96,7 +106,7 @@ private fun StockItemCompact(
                 RowOfHints(item)
 
             }
-            TheeDotsMenuButton(actions = actions)
+            StockItemMenu(actions)
         }
     }
 }
@@ -108,11 +118,25 @@ private fun StockItemName(
 ) {
     Text(
         text = name,
-        modifier = modifier,
+        modifier = modifier.skeleton(),
         style = MaterialTheme.typography.titleMedium,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis
     )
+}
+
+/**
+ * Three-dots overflow menu, or its skeleton placeholder while [LocalSkeletonState] is active.
+ * The real button is interactive, so during loading we swap in an inert circular placeholder
+ * rather than masking a live button.
+ */
+@Composable
+private fun StockItemMenu(actions: List<LabeledActionUi>) {
+    if (LocalSkeletonState.current.isActive) {
+        Box(Modifier.size(MaterialTheme.spacing.s12).skeleton(CircleShape))
+    } else {
+        TheeDotsMenuButton(actions = actions)
+    }
 }
 
 @Composable
@@ -128,13 +152,15 @@ private fun RowOfHints(
         item {
             HintCard(
                 text = item.quantity,
-                containerColor = MaterialTheme.colorScheme.primaryContainer
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier.skeleton()
             )
         }
 
         items(item.hints) { hint ->
             HintCard(
                 text = hint,
+                modifier = Modifier.skeleton()
             )
         }
     }
@@ -156,11 +182,12 @@ private fun RowOfHintsStatic(
 
         HintCard(
             text = item.quantity,
-            containerColor = MaterialTheme.colorScheme.primaryContainer
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.skeleton()
         )
 
         item.hints.forEach { hint ->
-            HintCard(text = hint)
+            HintCard(text = hint, modifier = Modifier.skeleton())
         }
     }
 }
@@ -179,14 +206,17 @@ private fun StockItemRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)
     ) {
-        PhotoHolder(size = MaterialTheme.spacing.s12) //TODO
+        PhotoHolder(
+            size = MaterialTheme.spacing.s12,
+            modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3))
+        ) //TODO
         StockItemName(item.name, modifier = Modifier.weight(1f))
 
         // Content-sized so the weighted name above pushes it to the right edge.
         // A LazyRow would fill the remaining width and starve the name (see StockItemCompact).
         RowOfHintsStatic(item)
 
-        TheeDotsMenuButton(actions = actions)
+        StockItemMenu(actions)
     }
 }
 
@@ -196,6 +226,7 @@ private fun ExpiryChip(consumptionDate: ConsumptionDateUi) {
     HintCard(
         text = consumptionDate.date,
         containerColor = containerColor,
+        modifier = Modifier.skeleton()
     )
 
 }
@@ -317,6 +348,42 @@ private fun StockItemRowPreview() {
                         quantity = "2 uds"
                     )
                 )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun StockItemSkeletonPreview() {
+    KrocyTheme {
+        Surface {
+            ProvideSkeleton(active = true) {
+                Column {
+                    StockItemCompact(
+                        modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                        actions = emptyList(),
+                        item = StockItemUi(
+                            id = 0,
+                            name = "Galletas María",
+                            hints = listOf("1 abierto"),
+                            consumptionDate = ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 2 días", expired = false),
+                            quantity = "3 Packs"
+                        )
+                    )
+                    HorizontalDivider()
+                    StockItemRow(
+                        modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                        actions = emptyList(),
+                        item = StockItemUi(
+                            id = 1,
+                            name = "Yogur natural",
+                            hints = listOf("8 unidades", "2 abiertos"),
+                            consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", expired = false),
+                            quantity = "3 uds"
+                        )
+                    )
+                }
             }
         }
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -95,18 +95,18 @@ private fun StockItemCompact(
         ) {
             PhotoHolder(
                 size = MaterialTheme.spacing.s18,
-                modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3))
+                modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3), id = item.id)
             ) //TODO
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
             ) {
-                StockItemName(item.name)
+                StockItemName(item.name, item.id)
 
                 RowOfHints(item)
 
             }
-            StockItemMenu(actions)
+            StockItemMenu(actions, id = item.id)
         }
     }
 }
@@ -114,11 +114,12 @@ private fun StockItemCompact(
 @Composable
 private fun StockItemName(
     name: String,
+    id: Int,
     modifier: Modifier = Modifier
 ) {
     Text(
         text = name,
-        modifier = modifier.skeleton(),
+        modifier = modifier.skeleton(id = id),
         style = MaterialTheme.typography.titleMedium,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis
@@ -131,9 +132,9 @@ private fun StockItemName(
  * rather than masking a live button.
  */
 @Composable
-private fun StockItemMenu(actions: List<LabeledActionUi>) {
+private fun StockItemMenu(actions: List<LabeledActionUi>, id: Int) {
     if (LocalSkeletonState.current.isActive) {
-        Box(Modifier.size(MaterialTheme.spacing.s12).skeleton(CircleShape))
+        Box(Modifier.size(MaterialTheme.spacing.s12).skeleton(CircleShape, id = id))
     } else {
         TheeDotsMenuButton(actions = actions)
     }
@@ -147,20 +148,20 @@ private fun RowOfHints(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
     ) {
-        item.consumptionDate?.let { item { ExpiryChip(item.consumptionDate) } }
+        item.consumptionDate?.let { item { ExpiryChip(item.consumptionDate, id = item.id) } }
 
         item {
             HintCard(
                 text = item.quantity,
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
-                modifier = Modifier.skeleton()
+                modifier = Modifier.skeleton(id = item.id)
             )
         }
 
         items(item.hints) { hint ->
             HintCard(
                 text = hint,
-                modifier = Modifier.skeleton()
+                modifier = Modifier.skeleton(id = item.id)
             )
         }
     }
@@ -178,16 +179,16 @@ private fun RowOfHintsStatic(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
     ) {
-        item.consumptionDate?.let { ExpiryChip(it) }
+        item.consumptionDate?.let { ExpiryChip(it, id = item.id) }
 
         HintCard(
             text = item.quantity,
             containerColor = MaterialTheme.colorScheme.primaryContainer,
-            modifier = Modifier.skeleton()
+            modifier = Modifier.skeleton(id = item.id)
         )
 
         item.hints.forEach { hint ->
-            HintCard(text = hint, modifier = Modifier.skeleton())
+            HintCard(text = hint, modifier = Modifier.skeleton(id = item.id))
         }
     }
 }
@@ -208,25 +209,25 @@ private fun StockItemRow(
     ) {
         PhotoHolder(
             size = MaterialTheme.spacing.s12,
-            modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3))
+            modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3), id = item.id)
         ) //TODO
-        StockItemName(item.name, modifier = Modifier.weight(1f))
+        StockItemName(modifier = Modifier.weight(1f), name = item.name, id = item.id)
 
         // Content-sized so the weighted name above pushes it to the right edge.
         // A LazyRow would fill the remaining width and starve the name (see StockItemCompact).
         RowOfHintsStatic(item)
 
-        StockItemMenu(actions)
+        StockItemMenu(actions, id = item.id)
     }
 }
 
 @Composable
-private fun ExpiryChip(consumptionDate: ConsumptionDateUi) {
+private fun ExpiryChip(consumptionDate: ConsumptionDateUi, id: Int) {
     val containerColor = expiryHintColor(consumptionDate)
     HintCard(
         text = consumptionDate.date,
         containerColor = containerColor,
-        modifier = Modifier.skeleton()
+        modifier = Modifier.skeleton(id = id)
     )
 
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -60,7 +60,7 @@ internal fun StockItemComp(
         ),
         LabeledActionUi(
             label = "Abrir", //TODO
-            contentDescription = "Acción de consumir un producto",
+            contentDescription = "Acción de abrir un producto",
             icon = Icons.Default.Drafts,
             onClick = { onOpen(item.id) }
         ),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -133,7 +133,7 @@ private fun StockItemName(
  */
 @Composable
 private fun StockItemMenu(actions: List<LabeledActionUi>, id: Int) {
-    if (LocalSkeletonState.current.isActive) {
+    if (LocalSkeletonState.current.targets(id)) {
         Box(Modifier.size(MaterialTheme.spacing.s12).skeleton(CircleShape, id = id))
     } else {
         TheeDotsMenuButton(actions = actions)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddBox
 import androidx.compose.material.icons.filled.Drafts
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
@@ -60,7 +60,7 @@ internal fun StockItemComp(
         LabeledActionUi(
             label = "Aumentar", //TODO
             contentDescription = "Acción de aumentar el stock de un producto",
-            icon = Icons.Default.KeyboardArrowUp, //TODO
+            icon = Icons.Default.AddBox,
             onClick = { onAdd(item.id) }
         )
     )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -25,6 +27,7 @@ import com.srfmolina.krocy.ui.presentation.common.HintCard
 import com.srfmolina.krocy.ui.presentation.common.PhotoHolder
 import com.srfmolina.krocy.ui.presentation.common.TheeDotsMenuButton
 import com.srfmolina.krocy.ui.presentation.common.model.ConsumptionDateUi
+import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.model.StockItemUi
 import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
 import com.srfmolina.krocy.ui.presentation.theme.extendedColorScheme
@@ -34,18 +37,32 @@ import com.srfmolina.krocy.ui.presentation.theme.spacing
 @Composable
 internal fun StockItemComp(
     item: StockItemUi,
+    onConsume: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val actions = listOf(
+        LabeledActionUi(
+            label = "Consumir", //TODO
+            contentDescription = "Acción de consumir un producto",
+            icon = Icons.Default.Restaurant,
+            onClick = { onConsume(item.id) }
+        )
+    )
+
     if (MaterialTheme.isCompact) {
-        StockItemCompact(item, modifier)
+        StockItemCompact(item, actions, modifier)
     } else {
-        StockItemRow(item, modifier)
+        StockItemRow(item, actions, modifier)
     }
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
+private fun StockItemCompact(
+    item: StockItemUi,
+    actions: List<LabeledActionUi>,
+    modifier: Modifier = Modifier
+) {
 
     Surface {
         Row(
@@ -63,7 +80,7 @@ private fun StockItemCompact(item: StockItemUi, modifier: Modifier = Modifier) {
                 RowOfHints(item)
 
             }
-            TheeDotsMenuButton(actions = emptyList()) //TODO
+            TheeDotsMenuButton(actions = actions)
         }
     }
 }
@@ -135,7 +152,11 @@ private fun RowOfHintsStatic(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun StockItemRow(item: StockItemUi, modifier: Modifier = Modifier) {
+private fun StockItemRow(
+    item: StockItemUi,
+    actions: List<LabeledActionUi>,
+    modifier: Modifier = Modifier
+) {
     Row(
         modifier = modifier
             .fillMaxWidth(),
@@ -149,7 +170,7 @@ private fun StockItemRow(item: StockItemUi, modifier: Modifier = Modifier) {
         // A LazyRow would fill the remaining width and starve the name (see StockItemCompact).
         RowOfHintsStatic(item)
 
-        TheeDotsMenuButton(actions = emptyList()) //TODO
+        TheeDotsMenuButton(actions = actions)
     }
 }
 
@@ -229,6 +250,7 @@ private fun StockItemCompactPreview(
         Surface {
             StockItemCompact(
                 modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                actions = emptyList(),
                 item = StockItemUi(
                     id = 0,
                     name = "Galletas María",
@@ -249,6 +271,7 @@ private fun StockItemRowPreview() {
             Column {
                 StockItemRow(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    actions = emptyList(),
                     item = StockItemUi(
                         id = 1, name = "Galletas María",
                         hints = listOf("2 paquetes", "1 abierto"),
@@ -259,6 +282,7 @@ private fun StockItemRowPreview() {
                 HorizontalDivider()
                 StockItemRow(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    actions = emptyList(),
                     item = StockItemUi(
                         id = 2, name = "Yogur natural",
                         hints = listOf("8 unidades", "2 abiertos"),
@@ -269,6 +293,7 @@ private fun StockItemRowPreview() {
                 HorizontalDivider()
                 StockItemRow(
                     modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                    actions = emptyList(),
                     item = StockItemUi(
                         id = 3, name = "Leche entera",
                         hints = listOf("3 briks", "1 abierto"),

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -95,8 +95,10 @@ private fun StockItemCompact(
         ) {
             PhotoHolder(
                 size = MaterialTheme.spacing.s18,
+                imageUrl = item.pictureUrl,
+                contentDescription = item.name,
                 modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3), id = item.id)
-            ) //TODO
+            )
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s1)
@@ -209,8 +211,10 @@ private fun StockItemRow(
     ) {
         PhotoHolder(
             size = MaterialTheme.spacing.s12,
+            imageUrl = item.pictureUrl,
+            contentDescription = item.name,
             modifier = Modifier.skeleton(RoundedCornerShape(MaterialTheme.spacing.s3), id = item.id)
-        ) //TODO
+        )
         StockItemName(modifier = Modifier.weight(1f), name = item.name, id = item.id)
 
         // Content-sized so the weighted name above pushes it to the right edge.
@@ -304,7 +308,8 @@ private fun StockItemCompactPreview(
                     name = "Galletas María",
                     hints = item.hints,
                     consumptionDate = item.consumptionDate,
-                    quantity = "3 Packs"
+                    quantity = "3 Packs",
+                    pictureUrl = null
                 )
             )
         }
@@ -324,7 +329,8 @@ private fun StockItemRowPreview() {
                         id = 1, name = "Galletas María",
                         hints = listOf("2 paquetes", "1 abierto"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 12 días", expired = false),
-                        quantity = "2 paquetes"
+                        quantity = "2 paquetes",
+                        pictureUrl = null
                     )
                 )
                 HorizontalDivider()
@@ -335,7 +341,8 @@ private fun StockItemRowPreview() {
                         id = 2, name = "Yogur natural",
                         hints = listOf("8 unidades", "2 abiertos"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", expired = false),
-                        quantity = "3 uds"
+                        quantity = "3 uds",
+                        pictureUrl = null
                     )
                 )
                 HorizontalDivider()
@@ -346,7 +353,8 @@ private fun StockItemRowPreview() {
                         id = 3, name = "Leche entera",
                         hints = listOf("3 briks", "1 abierto"),
                         consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "Hace 1 día", expired = true),
-                        quantity = "2 uds"
+                        quantity = "2 uds",
+                        pictureUrl = null
                     )
                 )
             }
@@ -368,8 +376,13 @@ private fun StockItemSkeletonPreview() {
                             id = 0,
                             name = "Galletas María",
                             hints = listOf("1 abierto"),
-                            consumptionDate = ConsumptionDateUi(ConsumptionType.PREFERENCE, "En 2 días", expired = false),
-                            quantity = "3 Packs"
+                            consumptionDate = ConsumptionDateUi(
+                                ConsumptionType.PREFERENCE,
+                                "En 2 días",
+                                expired = false
+                            ),
+                            quantity = "3 Packs",
+                            pictureUrl = null
                         )
                     )
                     HorizontalDivider()
@@ -381,7 +394,8 @@ private fun StockItemSkeletonPreview() {
                             name = "Yogur natural",
                             hints = listOf("8 unidades", "2 abiertos"),
                             consumptionDate = ConsumptionDateUi(ConsumptionType.EXPIRATION, "En 2 días", expired = false),
-                            quantity = "3 uds"
+                            quantity = "3 uds",
+                            pictureUrl = null
                         )
                     )
                 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/component/StockItemComp.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Drafts
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
@@ -38,6 +40,8 @@ import com.srfmolina.krocy.ui.presentation.theme.spacing
 internal fun StockItemComp(
     item: StockItemUi,
     onConsume: (Int) -> Unit,
+    onAdd: (Int) -> Unit,
+    onOpen: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val actions = listOf(
@@ -46,6 +50,18 @@ internal fun StockItemComp(
             contentDescription = "Acción de consumir un producto",
             icon = Icons.Default.Restaurant,
             onClick = { onConsume(item.id) }
+        ),
+        LabeledActionUi(
+            label = "Abrir", //TODO
+            contentDescription = "Acción de consumir un producto",
+            icon = Icons.Default.Drafts,
+            onClick = { onOpen(item.id) }
+        ),
+        LabeledActionUi(
+            label = "Aumentar", //TODO
+            contentDescription = "Acción de aumentar el stock de un producto",
+            icon = Icons.Default.KeyboardArrowUp, //TODO
+            onClick = { onAdd(item.id) }
         )
     )
 

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/mapper/StockUiMapper.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/mapper/StockUiMapper.kt
@@ -14,7 +14,8 @@ internal fun StockItem.toUi(): StockItemUi = StockItemUi(
     name = name,
     hints = hints,
     consumptionDate = consumptionDate?.toUi(),
-    quantity = quantity
+    quantity = quantity,
+    pictureUrl = pictureUrl
 )
 
 private fun ConsumptionDate.toUi(): ConsumptionDateUi = ConsumptionDateUi(

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/model/StockItemUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/model/StockItemUi.kt
@@ -7,5 +7,6 @@ internal data class StockItemUi(
     val name: String,
     val hints: List<String>,
     val consumptionDate: ConsumptionDateUi?,
-    val quantity: String
+    val quantity: String,
+    val pictureUrl: String?
 )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/navigation/StockNavigation.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/stock/navigation/StockNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockScreen
 import com.srfmolina.krocy.ui.presentation.navigation.NavigationItemUi
 import com.srfmolina.krocy.ui.presentation.navigation.StockRoute
@@ -17,11 +18,13 @@ internal fun NavController.navigateToStock(
 
 internal fun NavGraphBuilder.stockScreen(
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
     onOpenNavRail: () -> Unit
 ) {
     composable<StockRoute> {
         StockScreen(
             onChangeTopBar = onChangeTopBar,
+            onChangeFab =onChangeFab,
             onOpenNavRail = onOpenNavRail
         )
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/AppNavGraph.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/AppNavGraph.kt
@@ -3,6 +3,7 @@ package com.srfmolina.krocy.ui.presentation.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.feature.login.navigation.loginScreen
 import com.srfmolina.krocy.ui.presentation.feature.splash.navigation.splashScreen
 import com.srfmolina.krocy.ui.presentation.feature.stock.navigation.stockScreen
@@ -13,6 +14,7 @@ import kotlinx.serialization.Serializable
 internal fun NavGraphBuilder.appNavGraph(
     navController: NavController,
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
     onOpenNavRail: () -> Unit
 ){
     navigation<AppRoute>(
@@ -30,6 +32,7 @@ internal fun NavGraphBuilder.appNavGraph(
 
         stockScreen(
             onChangeTopBar = onChangeTopBar,
+            onChangeFab = onChangeFab,
             onOpenNavRail = onOpenNavRail
         )
     }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/NavigationComponent.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/NavigationComponent.kt
@@ -3,15 +3,17 @@ package com.srfmolina.krocy.ui.presentation.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
 
 @Composable
 internal fun NavigationComponent(
     navController: NavHostController,
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
     onOpenNavRail: () -> Unit
 ) {
     NavHost(navController = navController, startDestination = AppRoute) {
-        appNavGraph(navController, onChangeTopBar, onOpenNavRail)
+        appNavGraph(navController, onChangeTopBar, onChangeFab, onOpenNavRail)
     }
 }


### PR DESCRIPTION
## Overview

Adds stock actions (consume / open / add), a refresh capability, product pictures, and a shimmering loading skeleton system to the Stock feature. Also introduces a reusable centrally-managed FAB menu and reworks the stock repository's caching.

## What's new

### Stock actions
- **Consume / Open / Add** one unit of a product directly from each stock item's overflow (three-dots) menu.
- New `StockDataSource` operations backed by the Grocy endpoints `stock/products/{id}/consume`, `/open` and `/add`.
- Per-item loading state (`loadingItemIds`) so only the affected row shows its skeleton while the action is in flight; the list refreshes automatically on success.
- New one-shot use cases (`ConsumeStockUseCase`, `OpenStockUseCase`, `AddStockUseCase`, `RefreshStockUseCase`) built on a new `ResultUseCase` / `ResultUseCaseNoParams` base that wraps results and preserves cancellation semantics.

### Product pictures
- Stock items now load their product picture via **Coil 3** (`AsyncImage`), with `PhotoHolder` falling back to the existing placeholder box when no image is available.
- `buildProductPictureUrl` constructs Grocy's BASE64-encoded `/files/productpictures/...` serve URL with `best_fit_width` downscaling.
- Wired Coil's Ktor network backend per platform (OkHttp on Android, CIO on Desktop).

### Quantity unit names
- Stock quantities now display the product's real quantity-unit name (singular/plural), e.g. "3 Packs" instead of a hardcoded "uds".
- Added a `GenericEntityDataSource` to fetch quantity units via the generic-entities API. Worked around a broken generated `ExposedEntityNoListing` enum by aliasing `ExposedEntityNotIncludingNotListable` to the full `ExposedEntity`.

### Loading skeletons
- New shimmer skeleton system under `presentation/common/skeleton/`: `Modifier.skeleton`, `ProvideSkeleton`, `SkeletonState`, `SkeletonDefaults` and a `SkeletonTransitionAnimation` cross-fade.
- A single shared, screen-space shimmer phase keeps every placeholder in sync. Supports **targeted** skeletons (by item id) so individual rows can shimmer during an action.
- Representative dummy items drive the full-screen loading layout so placeholders match the real list's shape.

### FAB menu
- New `KrocyFabMenu` (Material 3 Expressive `FloatingActionButtonMenu`) rendered centrally from `App`, driven by a `FabConfigurationUi` pushed up through the nav graph — mirroring the existing top-bar mechanism (`onChangeFab`).
- The Stock screen exposes a **Refresh** action and auto-hides the FAB while scrolling down / loading.

### Repository caching rework
- `StockRepositoryImpl` now loads once via `ensureLoaded()` (mutex-guarded) instead of refetching on every subscription, with an explicit `forceRefresh()`.

## Notes
- Several user-facing strings are still hardcoded in Spanish and marked with `// TODO` for future localization.
- Error handling for actions is currently a `// TODO` placeholder (`onFailure` to be surfaced as an effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
