### PR TITLE
Shopping list

### DIFF
--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.data.datasource.remote.shoppinglist
 
+import org.openapitools.client.models.CurrentVolatilStockResponseMissingProductsInner
 import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 
 internal interface ShoppingListDataSource {
@@ -11,10 +12,26 @@ internal interface ShoppingListDataSource {
     /** Returns the rows of every shopping list; callers filter by `shopping_list_id`. */
     suspend fun getItems(): Result<List<ObjectsEntityGet200ResponseInner>>
 
+    /** Products currently below their min. stock amount; `amountMissing` is in stock units. */
+    suspend fun getMissingProducts(): Result<List<CurrentVolatilStockResponseMissingProductsInner>>
+
+    suspend fun createItem(
+        listId: Int,
+        productId: Int,
+        amount: Double,
+        quId: Int?,
+        note: String?,
+    ): Result<Unit>
+
+    /** Partial update; null [quId]/[note] leave the row's current values untouched. */
+    suspend fun updateItem(
+        itemId: Int,
+        amount: Double,
+        quId: Int?,
+        note: String? = null,
+    ): Result<Unit>
+
     suspend fun setDone(itemId: Int, done: Boolean): Result<Unit>
 
-    /** Adds products below their min. stock amount to the given list (idempotent). */
-    suspend fun addMissingProducts(listId: Int): Result<Unit>
-
-    suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit>
+    suspend fun deleteItem(itemId: Int): Result<Unit>
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
@@ -1,0 +1,20 @@
+package com.srfmolina.krocy.data.datasource.remote.shoppinglist
+
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+
+internal interface ShoppingListDataSource {
+    suspend fun getShoppingLists(): Result<List<ObjectsEntityGet200ResponseInner>>
+
+    /** Creates a shopping list and returns its generated id. */
+    suspend fun createShoppingList(name: String): Result<Int>
+
+    /** Returns the rows of every shopping list; callers filter by `shopping_list_id`. */
+    suspend fun getItems(): Result<List<ObjectsEntityGet200ResponseInner>>
+
+    suspend fun setDone(itemId: Int, done: Boolean): Result<Unit>
+
+    /** Adds products below their min. stock amount to the given list (idempotent). */
+    suspend fun addMissingProducts(listId: Int): Result<Unit>
+
+    suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit>
+}

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSource.kt
@@ -23,12 +23,17 @@ internal interface ShoppingListDataSource {
         note: String?,
     ): Result<Unit>
 
-    /** Partial update; null [quId]/[note] leave the row's current values untouched. */
+    /**
+     * Partial update; null [quId]/[note]/[done] leave the row's current values untouched.
+     * Note: because null is omitted from the body, a note can only be *cleared* by passing
+     * an explicit empty string.
+     */
     suspend fun updateItem(
         itemId: Int,
         amount: Double,
         quId: Int?,
         note: String? = null,
+        done: Boolean? = null,
     ): Result<Unit>
 
     suspend fun setDone(itemId: Int, done: Boolean): Result<Unit>

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
@@ -1,0 +1,54 @@
+package com.srfmolina.krocy.data.datasource.remote.shoppinglist
+
+import org.openapitools.client.apis.GenericEntityInteractionsApi
+import org.openapitools.client.apis.StockApi
+import org.openapitools.client.models.ExposedEntity
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+import org.openapitools.client.models.StockShoppinglistAddMissingProductsPostRequest
+import org.openapitools.client.models.StockShoppinglistAddProductPostRequest
+
+internal class ShoppingListDataSourceImpl(
+    private val stockApi: StockApi,
+    private val genericEntityApi: GenericEntityInteractionsApi,
+) : ShoppingListDataSource {
+
+    override suspend fun getShoppingLists(): Result<List<ObjectsEntityGet200ResponseInner>> = runCatching {
+        genericEntityApi.objectsEntityGet(entity = ExposedEntity.shopping_lists).body()
+    }
+
+    override suspend fun createShoppingList(name: String): Result<Int> = runCatching {
+        genericEntityApi.objectsEntityPost(
+            entity = ExposedEntity.shopping_lists,
+            objectsEntityGet200ResponseInner = ObjectsEntityGet200ResponseInner(name = name)
+        ).body().createdObjectId ?: error("Grocy did not return a created object id")
+    }
+
+    override suspend fun getItems(): Result<List<ObjectsEntityGet200ResponseInner>> = runCatching {
+        genericEntityApi.objectsEntityGet(entity = ExposedEntity.shopping_list).body()
+    }
+
+    override suspend fun setDone(itemId: Int, done: Boolean): Result<Unit> = runCatching {
+        // Partial body: encodeDefaults is off, so only `done` is serialized (see SPEC-DEVIATIONS.md #7).
+        genericEntityApi.objectsEntityObjectIdPut(
+            entity = ExposedEntity.shopping_list,
+            objectId = itemId,
+            objectsEntityGet200ResponseInner = ObjectsEntityGet200ResponseInner(done = if (done) 1 else 0)
+        ).body()
+    }
+
+    override suspend fun addMissingProducts(listId: Int): Result<Unit> = runCatching {
+        stockApi.stockShoppinglistAddMissingProductsPost(
+            StockShoppinglistAddMissingProductsPostRequest(listId = listId)
+        ).body()
+    }
+
+    override suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit> = runCatching {
+        stockApi.stockShoppinglistAddProductPost(
+            StockShoppinglistAddProductPostRequest(
+                productId = productId,
+                listId = listId,
+                productAmount = amount,
+            )
+        ).body()
+    }
+}

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
@@ -56,6 +56,7 @@ internal class ShoppingListDataSourceImpl(
         amount: Double,
         quId: Int?,
         note: String?,
+        done: Boolean?,
     ): Result<Unit> = runCatching {
         // Partial body: encodeDefaults is off, so unset fields are not serialized
         // and grocy leaves their columns untouched (see SPEC-DEVIATIONS.md #7).
@@ -66,6 +67,7 @@ internal class ShoppingListDataSourceImpl(
                 amount = amount,
                 quId = quId,
                 note = note,
+                done = done?.let { if (it) 1 else 0 },
             )
         ).body()
     }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/datasource/remote/shoppinglist/ShoppingListDataSourceImpl.kt
@@ -2,10 +2,9 @@ package com.srfmolina.krocy.data.datasource.remote.shoppinglist
 
 import org.openapitools.client.apis.GenericEntityInteractionsApi
 import org.openapitools.client.apis.StockApi
+import org.openapitools.client.models.CurrentVolatilStockResponseMissingProductsInner
 import org.openapitools.client.models.ExposedEntity
 import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
-import org.openapitools.client.models.StockShoppinglistAddMissingProductsPostRequest
-import org.openapitools.client.models.StockShoppinglistAddProductPostRequest
 
 internal class ShoppingListDataSourceImpl(
     private val stockApi: StockApi,
@@ -27,8 +26,51 @@ internal class ShoppingListDataSourceImpl(
         genericEntityApi.objectsEntityGet(entity = ExposedEntity.shopping_list).body()
     }
 
+    override suspend fun getMissingProducts(): Result<List<CurrentVolatilStockResponseMissingProductsInner>> =
+        runCatching {
+            stockApi.stockVolatileGet().body().missingProducts.orEmpty()
+        }
+
+    override suspend fun createItem(
+        listId: Int,
+        productId: Int,
+        amount: Double,
+        quId: Int?,
+        note: String?,
+    ): Result<Unit> = runCatching {
+        genericEntityApi.objectsEntityPost(
+            entity = ExposedEntity.shopping_list,
+            objectsEntityGet200ResponseInner = ObjectsEntityGet200ResponseInner(
+                shoppingListId = listId,
+                productId = productId,
+                amount = amount,
+                quId = quId,
+                note = note,
+            )
+        ).body()
+        Unit
+    }
+
+    override suspend fun updateItem(
+        itemId: Int,
+        amount: Double,
+        quId: Int?,
+        note: String?,
+    ): Result<Unit> = runCatching {
+        // Partial body: encodeDefaults is off, so unset fields are not serialized
+        // and grocy leaves their columns untouched (see SPEC-DEVIATIONS.md #7).
+        genericEntityApi.objectsEntityObjectIdPut(
+            entity = ExposedEntity.shopping_list,
+            objectId = itemId,
+            objectsEntityGet200ResponseInner = ObjectsEntityGet200ResponseInner(
+                amount = amount,
+                quId = quId,
+                note = note,
+            )
+        ).body()
+    }
+
     override suspend fun setDone(itemId: Int, done: Boolean): Result<Unit> = runCatching {
-        // Partial body: encodeDefaults is off, so only `done` is serialized (see SPEC-DEVIATIONS.md #7).
         genericEntityApi.objectsEntityObjectIdPut(
             entity = ExposedEntity.shopping_list,
             objectId = itemId,
@@ -36,19 +78,10 @@ internal class ShoppingListDataSourceImpl(
         ).body()
     }
 
-    override suspend fun addMissingProducts(listId: Int): Result<Unit> = runCatching {
-        stockApi.stockShoppinglistAddMissingProductsPost(
-            StockShoppinglistAddMissingProductsPostRequest(listId = listId)
-        ).body()
-    }
-
-    override suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit> = runCatching {
-        stockApi.stockShoppinglistAddProductPost(
-            StockShoppinglistAddProductPostRequest(
-                productId = productId,
-                listId = listId,
-                productAmount = amount,
-            )
+    override suspend fun deleteItem(itemId: Int): Result<Unit> = runCatching {
+        genericEntityApi.objectsEntityObjectIdDelete(
+            entity = ExposedEntity.shopping_list,
+            objectId = itemId,
         ).body()
     }
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
@@ -6,6 +6,8 @@ import com.srfmolina.krocy.data.datasource.remote.conversion.QuConversionDataSou
 import com.srfmolina.krocy.data.datasource.remote.conversion.QuConversionDataSourceImpl
 import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
 import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSourceImpl
+import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
+import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSourceImpl
 import com.srfmolina.krocy.data.datasource.remote.stock.StockDataSource
 import com.srfmolina.krocy.data.datasource.remote.stock.StockDataSourceImpl
 import com.srfmolina.krocy.data.db.KrocyDatabase
@@ -14,10 +16,12 @@ import com.srfmolina.krocy.data.db.dao.KrocyItemDao
 import com.srfmolina.krocy.data.repository.impl.KrocyItemRepositoryImpl
 import com.srfmolina.krocy.data.repository.impl.MasterRepositoryImpl
 import com.srfmolina.krocy.data.repository.impl.ProductRepositoryImpl
+import com.srfmolina.krocy.data.repository.impl.ShoppingListRepositoryImpl
 import com.srfmolina.krocy.data.repository.impl.StockRepositoryImpl
 import com.srfmolina.krocy.domain.repository.KrocyItemRepository
 import com.srfmolina.krocy.domain.repository.MasterRepository
 import com.srfmolina.krocy.domain.repository.ProductRepository
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
 import com.srfmolina.krocy.domain.repository.StockRepository
 import org.koin.dsl.module
 import org.openapitools.client.apis.GenericEntityInteractionsApi
@@ -38,11 +42,13 @@ val dataModule = module {
 
     single<KrocyItemDataSource> { KrocyItemDataSourceImpl(get()) }
     single<StockDataSource> { StockDataSourceImpl(get()) }
+    single<ShoppingListDataSource> { ShoppingListDataSourceImpl(get(), get()) }
     single<GenericEntityDataSource> { GenericEntityDataSourceImpl(get()) }
     single<QuConversionDataSource> { QuConversionDataSourceImpl(get()) }
 
     single<KrocyItemRepository> { KrocyItemRepositoryImpl(get()) }
     single<StockRepository> { StockRepositoryImpl(get(), get(), baseUrl) }
+    single<ShoppingListRepository> { ShoppingListRepositoryImpl(get(), get()) }
     single<MasterRepository> { MasterRepositoryImpl(get(), get()) }
     single<ProductRepository> { ProductRepositoryImpl(get(), get(), get()) }
 

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/ShoppingListMapper.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/ShoppingListMapper.kt
@@ -3,14 +3,18 @@ package com.srfmolina.krocy.data.mapper
 import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
 import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 
-/** Maps a `shopping_list` row to the domain, with the joined master data resolved by the caller. */
+/**
+ * Maps a `shopping_list` row to the domain, with the joined master data resolved by the
+ * caller. Null when the row has no server id or product id: such a row cannot be crossed
+ * off or deleted, so it must not render as a normal entry.
+ */
 internal fun ObjectsEntityGet200ResponseInner.toShoppingListEntry(
     productName: String,
     groupName: String?,
     unitNames: Pair<String, String>,
-): ShoppingListEntry = ShoppingListEntry(
-    id = id ?: 0,
-    productId = productId ?: 0,
+): ShoppingListEntry? = ShoppingListEntry(
+    id = id ?: return null,
+    productId = productId ?: return null,
     productName = productName,
     groupName = groupName,
     amount = amount ?: 0.0,

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/ShoppingListMapper.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/mapper/ShoppingListMapper.kt
@@ -1,0 +1,20 @@
+package com.srfmolina.krocy.data.mapper
+
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+
+/** Maps a `shopping_list` row to the domain, with the joined master data resolved by the caller. */
+internal fun ObjectsEntityGet200ResponseInner.toShoppingListEntry(
+    productName: String,
+    groupName: String?,
+    unitNames: Pair<String, String>,
+): ShoppingListEntry = ShoppingListEntry(
+    id = id ?: 0,
+    productId = productId ?: 0,
+    productName = productName,
+    groupName = groupName,
+    amount = amount ?: 0.0,
+    unitName = unitNames.first,
+    unitNamePlural = unitNames.second,
+    done = done == 1,
+)

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.srfmolina.krocy.data.repository.impl
 import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
 import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
 import com.srfmolina.krocy.data.mapper.toShoppingListEntry
-import com.srfmolina.krocy.data.repository.impl.ShoppingListRepositoryImpl.Companion.MANUAL_NOTE
 import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
 import com.srfmolina.krocy.domain.repository.ShoppingListRepository
 import kotlinx.coroutines.flow.Flow
@@ -53,13 +52,15 @@ internal class ShoppingListRepositoryImpl(
                 .filter { it.shoppingListId == id }
                 .firstOrNull { it.productId == productId }
             if (existing != null) {
-                // Merge into the existing row and claim it as manual, so the sync stops
-                // managing it: the user explicitly asked for more than the deficit.
+                // Merge and hand the row over to the user: clear the auto marker (the user
+                // overrode the deficit) and un-cross it (re-adding means it needs buying
+                // again — a crossed-off row would be cleared by the next sync).
                 shoppingListDataSource.updateItem(
                     itemId = existing.id ?: error("Shopping list row without id"),
                     amount = (existing.amount ?: 0.0) + amount,
                     quId = existing.quId,
-                    note = MANUAL_NOTE,
+                    note = if (existing.note == KROCY_AUTO) "" else null,
+                    done = false,
                 ).getOrThrow()
             } else {
                 shoppingListDataSource.createItem(
@@ -67,7 +68,7 @@ internal class ShoppingListRepositoryImpl(
                     productId = productId,
                     amount = amount,
                     quId = products.firstOrNull { it.id == productId }?.quIdStock,
-                    note = MANUAL_NOTE,
+                    note = null,
                 ).getOrThrow()
             }
             refreshItems(products)
@@ -94,22 +95,35 @@ internal class ShoppingListRepositoryImpl(
      * in stock units (verified against the demo server, 2026-07-09). So the deficits come from
      * `/stock/volatile` and the rows are managed here, always in stock units.
      *
-     * Rows added by hand carry [MANUAL_NOTE] and are never synced; a crossed-off manual row
-     * is considered bought and cleared on the next sync.
+     * Only rows carrying [KROCY_AUTO] are owned by this sync (created, resized, removed).
+     * Every other row — added here by hand, created in another grocy client, or note-only —
+     * is a user row: its amount and note are never touched, and it is deleted only once
+     * crossed off ("bought"), regardless of which client crossed it off.
      */
     private suspend fun reconcile(products: List<ObjectsEntityGet200ResponseInner>) {
         val id = ensureListId()
-        val missingByProduct = shoppingListDataSource.getMissingProducts().getOrThrow()
-            .mapNotNull { missing -> missing.id?.let { it to (missing.amountMissing ?: 0.0) } }
+        val missingProducts = shoppingListDataSource.getMissingProducts().getOrThrow()
+        // A null amountMissing is "unknown", not "no deficit": those products are skipped
+        // entirely, so their rows are neither resized nor deleted and none are created.
+        val unknownDeficits = missingProducts
+            .mapNotNull { missing -> missing.id.takeIf { missing.amountMissing == null } }
+            .toSet()
+        val missingByProduct = missingProducts
+            .mapNotNull { missing ->
+                val productId = missing.id ?: return@mapNotNull null
+                val amount = missing.amountMissing ?: return@mapNotNull null
+                productId to amount
+            }
             .toMap()
         val productsById = products.associateBy { it.id }
         val rows = shoppingListDataSource.getItems().getOrThrow()
             .filter { it.shoppingListId == id }
 
-        val (manualRows, autoRows) = rows.partition { it.note == MANUAL_NOTE }
+        val (autoRows, userRows) = rows.partition { it.note == KROCY_AUTO }
 
-        val (doneManualRows, keptManualRows) = manualRows.partition { it.done == 1 }
-        doneManualRows.forEach { row ->
+        // A crossed-off user row was bought: clear it.
+        val (doneUserRows, keptUserRows) = userRows.partition { it.done == 1 }
+        doneUserRows.forEach { row ->
             row.id?.let { shoppingListDataSource.deleteItem(it).getOrThrow() }
         }
 
@@ -117,8 +131,7 @@ internal class ShoppingListRepositoryImpl(
         autoRows.forEach { row ->
             val rowId = row.id ?: return@forEach
             val productId = row.productId
-            if (productId == null) {
-                // Note-only rows (other clients allow them): not ours to manage.
+            if (productId == null || productId in unknownDeficits) {
                 keptAutoRows += row
                 return@forEach
             }
@@ -127,16 +140,18 @@ internal class ShoppingListRepositoryImpl(
             if (deficit <= 0.0) {
                 shoppingListDataSource.deleteItem(rowId).getOrThrow()
             } else {
-                if (row.amount != deficit || row.quId != stockQuId) {
+                // Only compare units when the stock unit is known: a null quId is omitted
+                // from the PUT body, so that comparison could never converge.
+                if (row.amount != deficit || (stockQuId != null && row.quId != stockQuId)) {
                     shoppingListDataSource.updateItem(rowId, deficit, stockQuId).getOrThrow()
                 }
                 keptAutoRows += row
             }
         }
 
-        // Deficits with no row yet. A manual row counts as listed: the user already decided
+        // Deficits with no row yet. A user row counts as listed: the user already decided
         // how much of that product to buy.
-        val listedProducts = (keptManualRows + keptAutoRows).mapNotNull { it.productId }.toSet()
+        val listedProducts = (keptUserRows + keptAutoRows).mapNotNull { it.productId }.toSet()
         missingByProduct.forEach { (productId, deficit) ->
             if (deficit > 0.0 && productId !in listedProducts) {
                 shoppingListDataSource.createItem(
@@ -144,7 +159,7 @@ internal class ShoppingListRepositoryImpl(
                     productId = productId,
                     amount = deficit,
                     quId = productsById[productId]?.quIdStock,
-                    note = null,
+                    note = KROCY_AUTO,
                 ).getOrThrow()
             }
         }
@@ -187,7 +202,7 @@ internal class ShoppingListRepositoryImpl(
     private companion object {
         const val DEFAULT_LIST_NAME = "Lista de la compra"
 
-        /** Note marker on rows the user added by hand, which the deficit sync must not touch. */
-        const val MANUAL_NOTE = "krocy:manual"
+        /** Marker on rows this sync created for deficits; see [reconcile] for the ownership rules. */
+        const val KROCY_AUTO = "krocy:auto"
     }
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.srfmolina.krocy.data.repository.impl
 import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
 import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
 import com.srfmolina.krocy.data.mapper.toShoppingListEntry
+import com.srfmolina.krocy.data.repository.impl.ShoppingListRepositoryImpl.Companion.MANUAL_NOTE
 import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
 import com.srfmolina.krocy.domain.repository.ShoppingListRepository
 import kotlinx.coroutines.flow.Flow
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 
 internal class ShoppingListRepositoryImpl(
     private val shoppingListDataSource: ShoppingListDataSource,
@@ -46,8 +48,29 @@ internal class ShoppingListRepositoryImpl(
     override suspend fun addProduct(productId: Int, amount: Double) {
         refreshMutex.withLock {
             val id = ensureListId()
-            shoppingListDataSource.addProduct(id, productId, amount).getOrThrow()
-            refreshItems()
+            val products = genericEntityDataSource.getProducts().getOrThrow()
+            val existing = shoppingListDataSource.getItems().getOrThrow()
+                .filter { it.shoppingListId == id }
+                .firstOrNull { it.productId == productId }
+            if (existing != null) {
+                // Merge into the existing row and claim it as manual, so the sync stops
+                // managing it: the user explicitly asked for more than the deficit.
+                shoppingListDataSource.updateItem(
+                    itemId = existing.id ?: error("Shopping list row without id"),
+                    amount = (existing.amount ?: 0.0) + amount,
+                    quId = existing.quId,
+                    note = MANUAL_NOTE,
+                ).getOrThrow()
+            } else {
+                shoppingListDataSource.createItem(
+                    listId = id,
+                    productId = productId,
+                    amount = amount,
+                    quId = products.firstOrNull { it.id == productId }?.quIdStock,
+                    note = MANUAL_NOTE,
+                ).getOrThrow()
+            }
+            refreshItems(products)
         }
     }
 
@@ -58,9 +81,73 @@ internal class ShoppingListRepositoryImpl(
     }
 
     private suspend fun syncAndRefresh() {
-        shoppingListDataSource.addMissingProducts(ensureListId()).getOrThrow()
-        refreshItems()
+        val products = genericEntityDataSource.getProducts().getOrThrow()
+        reconcile(products)
+        refreshItems(products)
         loaded = true
+    }
+
+    /**
+     * Brings the list in line with the current min-stock deficits. Grocy's own
+     * `add-missing-products` endpoint cannot do this: it never updates amounts, never removes
+     * satisfied rows, and stamps rows with the purchase unit although the amount it writes is
+     * in stock units (verified against the demo server, 2026-07-09). So the deficits come from
+     * `/stock/volatile` and the rows are managed here, always in stock units.
+     *
+     * Rows added by hand carry [MANUAL_NOTE] and are never synced; a crossed-off manual row
+     * is considered bought and cleared on the next sync.
+     */
+    private suspend fun reconcile(products: List<ObjectsEntityGet200ResponseInner>) {
+        val id = ensureListId()
+        val missingByProduct = shoppingListDataSource.getMissingProducts().getOrThrow()
+            .mapNotNull { missing -> missing.id?.let { it to (missing.amountMissing ?: 0.0) } }
+            .toMap()
+        val productsById = products.associateBy { it.id }
+        val rows = shoppingListDataSource.getItems().getOrThrow()
+            .filter { it.shoppingListId == id }
+
+        val (manualRows, autoRows) = rows.partition { it.note == MANUAL_NOTE }
+
+        val (doneManualRows, keptManualRows) = manualRows.partition { it.done == 1 }
+        doneManualRows.forEach { row ->
+            row.id?.let { shoppingListDataSource.deleteItem(it).getOrThrow() }
+        }
+
+        val keptAutoRows = mutableListOf<ObjectsEntityGet200ResponseInner>()
+        autoRows.forEach { row ->
+            val rowId = row.id ?: return@forEach
+            val productId = row.productId
+            if (productId == null) {
+                // Note-only rows (other clients allow them): not ours to manage.
+                keptAutoRows += row
+                return@forEach
+            }
+            val deficit = missingByProduct[productId] ?: 0.0
+            val stockQuId = productsById[productId]?.quIdStock
+            if (deficit <= 0.0) {
+                shoppingListDataSource.deleteItem(rowId).getOrThrow()
+            } else {
+                if (row.amount != deficit || row.quId != stockQuId) {
+                    shoppingListDataSource.updateItem(rowId, deficit, stockQuId).getOrThrow()
+                }
+                keptAutoRows += row
+            }
+        }
+
+        // Deficits with no row yet. A manual row counts as listed: the user already decided
+        // how much of that product to buy.
+        val listedProducts = (keptManualRows + keptAutoRows).mapNotNull { it.productId }.toSet()
+        missingByProduct.forEach { (productId, deficit) ->
+            if (deficit > 0.0 && productId !in listedProducts) {
+                shoppingListDataSource.createItem(
+                    listId = id,
+                    productId = productId,
+                    amount = deficit,
+                    quId = productsById[productId]?.quIdStock,
+                    note = null,
+                ).getOrThrow()
+            }
+        }
     }
 
     /** First existing shopping list, or a newly created one — grocy servers can have none at all. */
@@ -73,18 +160,18 @@ internal class ShoppingListRepositoryImpl(
         return id
     }
 
-    private suspend fun refreshItems() {
+    private suspend fun refreshItems(products: List<ObjectsEntityGet200ResponseInner>) {
         val id = ensureListId()
         val rows = shoppingListDataSource.getItems().getOrThrow()
             .filter { it.shoppingListId == id }
-        val products = genericEntityDataSource.getProducts().getOrThrow().associateBy { it.id }
+        val productsById = products.associateBy { it.id }
         val groups = genericEntityDataSource.getProductGroups().getOrThrow().associateBy { it.id }
         val units = genericEntityDataSource.getQuantityUnits().getOrThrow().associateBy { it.id }
 
         _cache.update {
             rows.mapNotNull { row ->
                 // Note-only rows (no product) are possible in grocy; the list shows products only.
-                val product = products[row.productId] ?: return@mapNotNull null
+                val product = productsById[row.productId] ?: return@mapNotNull null
                 val unit = units[row.quId ?: product.quIdStock]
                 val singularName = unit?.name ?: "ud"
                 val pluralName = unit?.namePlural?.takeIf { it.isNotBlank() } ?: singularName
@@ -99,5 +186,8 @@ internal class ShoppingListRepositoryImpl(
 
     private companion object {
         const val DEFAULT_LIST_NAME = "Lista de la compra"
+
+        /** Note marker on rows the user added by hand, which the deficit sync must not touch. */
+        const val MANUAL_NOTE = "krocy:manual"
     }
 }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
@@ -37,10 +37,14 @@ internal class ShoppingListRepositoryImpl(
     }
 
     override suspend fun setDone(entryId: Int, done: Boolean) {
-        shoppingListDataSource.setDone(entryId, done).getOrThrow()
-        // Patch the cache in place: a full refetch here would defeat the instant cross-off.
-        _cache.update { entries ->
-            entries.map { if (it.id == entryId) it.copy(done = done) else it }
+        // Serialized with refreshes: otherwise a refresh that fetched its rows before this
+        // PUT would later overwrite the patch below with its stale snapshot.
+        refreshMutex.withLock {
+            shoppingListDataSource.setDone(entryId, done).getOrThrow()
+            // Patch the cache in place: a full refetch here would defeat the instant cross-off.
+            _cache.update { entries ->
+                entries.map { if (it.id == entryId) it.copy(done = done) else it }
+            }
         }
     }
 
@@ -183,19 +187,18 @@ internal class ShoppingListRepositoryImpl(
         val groups = genericEntityDataSource.getProductGroups().getOrThrow().associateBy { it.id }
         val units = genericEntityDataSource.getQuantityUnits().getOrThrow().associateBy { it.id }
 
-        _cache.update {
-            rows.mapNotNull { row ->
-                // Note-only rows (no product) are possible in grocy; the list shows products only.
-                val product = productsById[row.productId] ?: return@mapNotNull null
-                val unit = units[row.quId ?: product.quIdStock]
-                val singularName = unit?.name ?: "ud"
-                val pluralName = unit?.namePlural?.takeIf { it.isNotBlank() } ?: singularName
-                row.toShoppingListEntry(
-                    productName = product.name.orEmpty(),
-                    groupName = groups[product.productGroupId]?.name?.takeIf { it.isNotBlank() },
-                    unitNames = Pair(singularName, pluralName),
-                )
-            }
+        _cache.value = rows.mapNotNull { row ->
+            // Rows that can't be resolved to a product aren't renderable: note-only rows
+            // (other clients allow them) and rows whose product is missing from the fetch.
+            val product = productsById[row.productId] ?: return@mapNotNull null
+            val unit = units[row.quId ?: product.quIdStock]
+            val singularName = unit?.name ?: "ud"
+            val pluralName = unit?.namePlural?.takeIf { it.isNotBlank() } ?: singularName
+            row.toShoppingListEntry(
+                productName = product.name.orEmpty(),
+                groupName = groups[product.productGroupId]?.name?.takeIf { it.isNotBlank() },
+                unitNames = Pair(singularName, pluralName),
+            )
         }
     }
 

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImpl.kt
@@ -1,0 +1,103 @@
+package com.srfmolina.krocy.data.repository.impl
+
+import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
+import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
+import com.srfmolina.krocy.data.mapper.toShoppingListEntry
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class ShoppingListRepositoryImpl(
+    private val shoppingListDataSource: ShoppingListDataSource,
+    private val genericEntityDataSource: GenericEntityDataSource,
+) : ShoppingListRepository {
+
+    private val _cache = MutableStateFlow<List<ShoppingListEntry>>(emptyList())
+
+    private val refreshMutex = Mutex()
+    @Volatile private var loaded = false
+    @Volatile private var listId: Int? = null
+
+    override fun getShoppingList(): Flow<List<ShoppingListEntry>> = _cache
+        .onSubscription { ensureLoaded() }
+
+    /** Syncs min-stock deficits and loads the list once; later subscribers reuse the cached value. */
+    private suspend fun ensureLoaded() {
+        if (loaded) return
+        refreshMutex.withLock {
+            if (loaded) return
+            syncAndRefresh()
+        }
+    }
+
+    override suspend fun setDone(entryId: Int, done: Boolean) {
+        shoppingListDataSource.setDone(entryId, done).getOrThrow()
+        // Patch the cache in place: a full refetch here would defeat the instant cross-off.
+        _cache.update { entries ->
+            entries.map { if (it.id == entryId) it.copy(done = done) else it }
+        }
+    }
+
+    override suspend fun addProduct(productId: Int, amount: Double) {
+        refreshMutex.withLock {
+            val id = ensureListId()
+            shoppingListDataSource.addProduct(id, productId, amount).getOrThrow()
+            refreshItems()
+        }
+    }
+
+    override suspend fun forceRefresh() {
+        refreshMutex.withLock {
+            syncAndRefresh()
+        }
+    }
+
+    private suspend fun syncAndRefresh() {
+        shoppingListDataSource.addMissingProducts(ensureListId()).getOrThrow()
+        refreshItems()
+        loaded = true
+    }
+
+    /** First existing shopping list, or a newly created one — grocy servers can have none at all. */
+    private suspend fun ensureListId(): Int {
+        listId?.let { return it }
+        val lists = shoppingListDataSource.getShoppingLists().getOrThrow()
+        val id = lists.firstOrNull()?.id
+            ?: shoppingListDataSource.createShoppingList(DEFAULT_LIST_NAME).getOrThrow()
+        listId = id
+        return id
+    }
+
+    private suspend fun refreshItems() {
+        val id = ensureListId()
+        val rows = shoppingListDataSource.getItems().getOrThrow()
+            .filter { it.shoppingListId == id }
+        val products = genericEntityDataSource.getProducts().getOrThrow().associateBy { it.id }
+        val groups = genericEntityDataSource.getProductGroups().getOrThrow().associateBy { it.id }
+        val units = genericEntityDataSource.getQuantityUnits().getOrThrow().associateBy { it.id }
+
+        _cache.update {
+            rows.mapNotNull { row ->
+                // Note-only rows (no product) are possible in grocy; the list shows products only.
+                val product = products[row.productId] ?: return@mapNotNull null
+                val unit = units[row.quId ?: product.quIdStock]
+                val singularName = unit?.name ?: "ud"
+                val pluralName = unit?.namePlural?.takeIf { it.isNotBlank() } ?: singularName
+                row.toShoppingListEntry(
+                    productName = product.name.orEmpty(),
+                    groupName = groups[product.productGroupId]?.name?.takeIf { it.isNotBlank() },
+                    unitNames = Pair(singularName, pluralName),
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_LIST_NAME = "Lista de la compra"
+    }
+}

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDeserializationTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/datasource/remote/generic/GenericEntityDeserializationTest.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.data.datasource.remote.generic
 
+import kotlinx.serialization.json.jsonObject
 import org.openapitools.client.infrastructure.ApiClient
 import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 import org.openapitools.client.models.ProductDetailsResponse
@@ -55,6 +56,35 @@ class GenericEntityDeserializationTest {
         )
 
         assertEquals(2, parsed.product?.id)
+    }
+
+    @Test
+    fun `parses shopping list rows with done and qu_id`() {
+        // Real payload shape from GET /objects/shopping_list (demo server, 2026-07-09):
+        // the spec omits done and qu_id, added manually here (see SPEC-DEVIATIONS.md #7).
+        val parsed = ApiClient.JSON_DEFAULT.decodeFromString<List<ObjectsEntityGet200ResponseInner>>(
+            """[{"id":10,"product_id":1,"note":null,"amount":5,""" +
+                """"row_created_timestamp":"2026-07-09 19:09:07","shopping_list_id":2,"done":0,"qu_id":3},""" +
+                """{"id":11,"product_id":2,"note":null,"amount":8,""" +
+                """"row_created_timestamp":"2026-07-09 19:09:07","shopping_list_id":2,"done":1,"qu_id":3,""" +
+                """"userfields":null}]"""
+        )
+
+        assertEquals(0, parsed[0].done)
+        assertEquals(1, parsed[1].done)
+        assertEquals(3, parsed[0].quId)
+        assertEquals(2, parsed[0].shoppingListId)
+        assertEquals(5.0, parsed[0].amount)
+    }
+
+    @Test
+    fun `encodes a done-only body for the shopping list PUT`() {
+        // Crossing an item off PUTs a partial body; with encodeDefaults off only the set field
+        // is serialized, so grocy updates just the done column (see SPEC-DEVIATIONS.md #7).
+        val body = ApiClient.JSON_DEFAULT.encodeToString(ObjectsEntityGet200ResponseInner(done = 1))
+
+        val keys = ApiClient.JSON_DEFAULT.parseToJsonElement(body).jsonObject.keys
+        assertEquals(setOf("done"), keys)
     }
 
     @Test

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
@@ -1,0 +1,136 @@
+package com.srfmolina.krocy.data.repository.impl
+
+import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSource
+import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShoppingListRepositoryImplTest {
+
+    private val genericStub = object : GenericEntityDataSource {
+        override suspend fun getQuantityUnits() = Result.success(listOf(
+            ObjectsEntityGet200ResponseInner(id = 3, name = "brik", namePlural = "briks"),
+        ))
+        override suspend fun getLocations() = Result.success(emptyList<ObjectsEntityGet200ResponseInner>())
+        override suspend fun getProductGroups() = Result.success(listOf(
+            ObjectsEntityGet200ResponseInner(id = 4, name = "Lácteos"),
+        ))
+        override suspend fun createProduct(body: ObjectsEntityGet200ResponseInner) = Result.success(1)
+        override suspend fun getProducts() = Result.success(listOf(
+            ObjectsEntityGet200ResponseInner(id = 1, name = "Leche entera", productGroupId = 4, quIdStock = 3),
+            ObjectsEntityGet200ResponseInner(id = 2, name = "Pan de molde"),
+        ))
+        override suspend fun getShoppingLocations() = Result.success(emptyList<ObjectsEntityGet200ResponseInner>())
+    }
+
+    private class ShoppingListDataSourceStub(
+        var lists: List<ObjectsEntityGet200ResponseInner> = listOf(ObjectsEntityGet200ResponseInner(id = 2)),
+    ) : ShoppingListDataSource {
+        var createdListName: String? = null
+        var missingProductsListId: Int? = null
+        val doneCalls = mutableListOf<Pair<Int, Boolean>>()
+        val addedProducts = mutableListOf<Triple<Int, Int, Double>>()
+        var itemFetches = 0
+        var items = listOf(
+            ObjectsEntityGet200ResponseInner(id = 10, productId = 1, amount = 5.0, quId = 3, shoppingListId = 2, done = 0),
+            ObjectsEntityGet200ResponseInner(id = 11, productId = 2, amount = 1.0, shoppingListId = 2, done = 1),
+            // Another list's row and a note-only row: both must be ignored.
+            ObjectsEntityGet200ResponseInner(id = 12, productId = 1, amount = 2.0, shoppingListId = 9, done = 0),
+            ObjectsEntityGet200ResponseInner(id = 13, note = "solo nota", shoppingListId = 2, done = 0),
+        )
+
+        override suspend fun getShoppingLists() = Result.success(lists)
+
+        override suspend fun createShoppingList(name: String): Result<Int> {
+            createdListName = name
+            return Result.success(2)
+        }
+
+        override suspend fun getItems(): Result<List<ObjectsEntityGet200ResponseInner>> {
+            itemFetches++
+            return Result.success(items)
+        }
+
+        override suspend fun setDone(itemId: Int, done: Boolean): Result<Unit> {
+            doneCalls += itemId to done
+            return Result.success(Unit)
+        }
+
+        override suspend fun addMissingProducts(listId: Int): Result<Unit> {
+            missingProductsListId = listId
+            return Result.success(Unit)
+        }
+
+        override suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit> {
+            addedProducts += Triple(listId, productId, amount)
+            return Result.success(Unit)
+        }
+    }
+
+    @Test
+    fun `first collection syncs missing products and joins master data`() = runBlocking {
+        val stub = ShoppingListDataSourceStub()
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entries = repo.getShoppingList().first()
+
+        assertEquals(2, stub.missingProductsListId)
+        assertEquals(2, entries.size)
+
+        val milk = entries.first { it.id == 10 }
+        assertEquals("Leche entera", milk.productName)
+        assertEquals("Lácteos", milk.groupName)
+        assertEquals(5.0, milk.amount)
+        assertEquals("brik", milk.unitName)
+        assertEquals("briks", milk.unitNamePlural)
+        assertFalse(milk.done)
+
+        val bread = entries.first { it.id == 11 }
+        assertEquals("Pan de molde", bread.productName)
+        assertEquals(null, bread.groupName)
+        // No qu_id on the row and no stock unit on the product: generic fallback names.
+        assertEquals("ud", bread.unitName)
+        assertTrue(bread.done)
+    }
+
+    @Test
+    fun `creates a shopping list when the server has none`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(lists = emptyList())
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        repo.getShoppingList().first()
+
+        assertEquals("Lista de la compra", stub.createdListName)
+        assertEquals(2, stub.missingProductsListId)
+    }
+
+    @Test
+    fun `setDone updates the row and patches the cache without refetching`() = runBlocking {
+        val stub = ShoppingListDataSourceStub()
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+        repo.getShoppingList().first()
+
+        repo.setDone(entryId = 10, done = true)
+
+        assertEquals(listOf(10 to true), stub.doneCalls)
+        assertTrue(repo.getShoppingList().first().first { it.id == 10 }.done)
+        assertEquals(1, stub.itemFetches)
+    }
+
+    @Test
+    fun `addProduct forwards the request and refreshes the list`() = runBlocking {
+        val stub = ShoppingListDataSourceStub()
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+        repo.getShoppingList().first()
+
+        repo.addProduct(productId = 2, amount = 3.0)
+
+        assertEquals(listOf(Triple(2, 2, 3.0)), stub.addedProducts)
+        assertEquals(2, stub.itemFetches)
+    }
+}

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ShoppingListRepositoryImplTest {
@@ -39,6 +40,7 @@ class ShoppingListRepositoryImplTest {
     ) : ShoppingListDataSource {
         var createdListName: String? = null
         val doneCalls = mutableListOf<Pair<Int, Boolean>>()
+        val updatedIds = mutableListOf<Int>()
         var itemFetches = 0
         private var nextId = 100
 
@@ -80,12 +82,15 @@ class ShoppingListRepositoryImplTest {
             amount: Double,
             quId: Int?,
             note: String?,
+            done: Boolean?,
         ): Result<Unit> {
+            updatedIds += itemId
             val index = items.indexOfFirst { it.id == itemId }
             items[index] = items[index].copy(
                 amount = amount,
                 quId = quId ?: items[index].quId,
                 note = note ?: items[index].note,
+                done = done?.let { if (it) 1 else 0 } ?: items[index].done,
             )
             return Result.success(Unit)
         }
@@ -104,10 +109,20 @@ class ShoppingListRepositoryImplTest {
     private fun missing(productId: Int, amount: Double) =
         CurrentVolatilStockResponseMissingProductsInner(id = productId, amountMissing = amount)
 
+    /** A row the deficit sync owns: carries the krocy:auto marker. */
     private fun autoRow(id: Int, productId: Int, amount: Double, quId: Int?, done: Int = 0) =
         ObjectsEntityGet200ResponseInner(
-            id = id, shoppingListId = 2, productId = productId, amount = amount, quId = quId, done = done,
+            id = id, shoppingListId = 2, productId = productId, amount = amount, quId = quId,
+            done = done, note = "krocy:auto",
         )
+
+    /** A row the sync does not own: added by hand here, in another client, or note-only. */
+    private fun userRow(
+        id: Int, productId: Int?, amount: Double, quId: Int?, done: Int = 0, note: String? = null,
+    ) = ObjectsEntityGet200ResponseInner(
+        id = id, shoppingListId = 2, productId = productId, amount = amount, quId = quId,
+        done = done, note = note,
+    )
 
     @Test
     fun `a deficit without a row is added in stock units and joined with master data`() = runBlocking {
@@ -124,6 +139,7 @@ class ShoppingListRepositoryImplTest {
         assertEquals("lata", entry.unitName)
         assertEquals("latas", entry.unitNamePlural)
         assertFalse(entry.done)
+        assertEquals("krocy:auto", stub.items.single().note)
     }
 
     @Test
@@ -157,31 +173,31 @@ class ShoppingListRepositoryImplTest {
     }
 
     @Test
-    fun `manual rows are preserved and crossed-off manual rows are cleared on sync`() = runBlocking {
+    fun `user rows are preserved and crossed-off user rows are cleared on sync`() = runBlocking {
         val stub = ShoppingListDataSourceStub(
             missing = emptyList(),
             items = mutableListOf(
-                autoRow(id = 30, productId = 1, amount = 2.0, quId = 6).copy(note = "krocy:manual"),
-                autoRow(id = 31, productId = 2, amount = 1.0, quId = null, done = 1).copy(note = "krocy:manual"),
+                userRow(id = 30, productId = 1, amount = 2.0, quId = 6, note = "solo eco"),
+                userRow(id = 31, productId = 2, amount = 1.0, quId = null, done = 1),
             ),
         )
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
 
         val entries = repo.getShoppingList().first()
 
-        // The pending manual row survives although its product has no deficit...
+        // The pending user row survives untouched although its product has no deficit...
         assertEquals(listOf(30), entries.map { it.id })
-        // ...and the crossed-off one was bought: cleared.
+        assertEquals("solo eco", stub.items.single().note)
+        assertEquals(2.0, stub.items.single().amount)
+        // ...and the crossed-off one was bought: cleared, whichever client crossed it off.
         assertEquals(listOf(30), stub.items.map { it.id })
     }
 
     @Test
-    fun `a deficit for a manually listed product does not create a second row`() = runBlocking {
+    fun `a deficit for a product already listed by the user does not create a second row`() = runBlocking {
         val stub = ShoppingListDataSourceStub(
             missing = listOf(missing(productId = 1, amount = 3.0)),
-            items = mutableListOf(
-                autoRow(id = 30, productId = 1, amount = 5.0, quId = 6).copy(note = "krocy:manual"),
-            ),
+            items = mutableListOf(userRow(id = 30, productId = 1, amount = 5.0, quId = 6)),
         )
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
 
@@ -193,7 +209,7 @@ class ShoppingListRepositoryImplTest {
     }
 
     @Test
-    fun `manual add creates a marked row with the product's stock unit`() = runBlocking {
+    fun `manual add creates an unmarked user row with the product's stock unit`() = runBlocking {
         val stub = ShoppingListDataSourceStub()
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
         repo.getShoppingList().first()
@@ -201,17 +217,17 @@ class ShoppingListRepositoryImplTest {
         repo.addProduct(productId = 1, amount = 2.0)
 
         val row = stub.items.single()
-        assertEquals("krocy:manual", row.note)
+        assertNull(row.note)
         assertEquals(6, row.quId)
         assertEquals(2.0, row.amount)
         assertEquals(2.0, repo.getShoppingList().first().single().amount)
     }
 
     @Test
-    fun `manual add merges into an existing row and claims it as manual`() = runBlocking {
+    fun `manual add merges into an auto row, clears the marker and un-crosses it`() = runBlocking {
         val stub = ShoppingListDataSourceStub(
             missing = listOf(missing(productId = 1, amount = 3.0)),
-            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 6)),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 6, done = 1)),
         )
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
         repo.getShoppingList().first()
@@ -220,7 +236,8 @@ class ShoppingListRepositoryImplTest {
 
         val row = stub.items.single()
         assertEquals(5.0, row.amount)
-        assertEquals("krocy:manual", row.note)
+        assertEquals("", row.note)
+        assertEquals(0, row.done)
     }
 
     @Test
@@ -261,5 +278,75 @@ class ShoppingListRepositoryImplTest {
 
         assertTrue(entries.isEmpty())
         assertEquals(listOf(40), stub.items.map { it.id })
+    }
+
+    @Test
+    fun `re-adding a crossed-off product un-crosses the row instead of losing it`() = runBlocking {
+        val stub = ShoppingListDataSourceStub()
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+        repo.getShoppingList().first()
+        repo.addProduct(productId = 1, amount = 3.0)
+        // The user crosses it off (e.g. in another client)...
+        stub.items[0] = stub.items[0].copy(done = 1)
+
+        // ...then asks for 2 more of it.
+        repo.addProduct(productId = 1, amount = 2.0)
+
+        val row = stub.items.single()
+        assertEquals(5.0, row.amount)
+        assertEquals(0, row.done)
+        // The next sync must keep it: it is a pending user row again, not a bought one.
+        repo.forceRefresh()
+        assertEquals(5.0, repo.getShoppingList().first().single().amount)
+    }
+
+    @Test
+    fun `a crossed-off auto row with a live deficit stays, crossed off`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(missing(productId = 1, amount = 3.0)),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 6, done = 1)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entry = repo.getShoppingList().first().single()
+
+        assertTrue(entry.done)
+        assertEquals(listOf(21), stub.items.map { it.id })
+    }
+
+    @Test
+    fun `an unknown deficit amount leaves the product's rows alone and creates nothing`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(
+                CurrentVolatilStockResponseMissingProductsInner(id = 1, amountMissing = null),
+                CurrentVolatilStockResponseMissingProductsInner(id = 2, amountMissing = null),
+            ),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 6)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entries = repo.getShoppingList().first()
+
+        // Unknown is not zero: the auto row is neither resized nor deleted,
+        // and no row is created for product 2.
+        assertEquals(listOf(21), stub.items.map { it.id })
+        assertEquals(3.0, stub.items.single().amount)
+        assertTrue(stub.updatedIds.isEmpty())
+        assertEquals(listOf(21), entries.map { it.id })
+    }
+
+    @Test
+    fun `no update is issued when the product has no stock unit and the amount matches`() = runBlocking {
+        // Product 2 has no quIdStock; comparing the row's quId against null can never
+        // converge (null is omitted from the PUT body), so it must not trigger updates.
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(missing(productId = 2, amount = 1.0)),
+            items = mutableListOf(autoRow(id = 21, productId = 2, amount = 1.0, quId = 3)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        repo.getShoppingList().first()
+
+        assertTrue(stub.updatedIds.isEmpty())
     }
 }

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
@@ -336,6 +336,19 @@ class ShoppingListRepositoryImplTest {
     }
 
     @Test
+    fun `rows without a server id are not emitted`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = emptyList(),
+            items = mutableListOf(userRow(id = 30, productId = 1, amount = 2.0, quId = 6).copy(id = null)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        // A row with no id cannot be crossed off or deleted; emitting it with id 0 would
+        // render a tappable entry whose PUT goes to /objects/shopping_list/0.
+        assertTrue(repo.getShoppingList().first().isEmpty())
+    }
+
+    @Test
     fun `no update is issued when the product has no stock unit and the amount matches`() = runBlocking {
         // Product 2 has no quIdStock; comparing the row's quId against null can never
         // converge (null is omitted from the PUT body), so it must not trigger updates.

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/repository/impl/ShoppingListRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import com.srfmolina.krocy.data.datasource.remote.generic.GenericEntityDataSourc
 import com.srfmolina.krocy.data.datasource.remote.shoppinglist.ShoppingListDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.openapitools.client.models.CurrentVolatilStockResponseMissingProductsInner
 import org.openapitools.client.models.ObjectsEntityGet200ResponseInner
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,35 +15,32 @@ class ShoppingListRepositoryImplTest {
 
     private val genericStub = object : GenericEntityDataSource {
         override suspend fun getQuantityUnits() = Result.success(listOf(
-            ObjectsEntityGet200ResponseInner(id = 3, name = "brik", namePlural = "briks"),
+            ObjectsEntityGet200ResponseInner(id = 3, name = "pack", namePlural = "packs"),
+            ObjectsEntityGet200ResponseInner(id = 6, name = "lata", namePlural = "latas"),
         ))
         override suspend fun getLocations() = Result.success(emptyList<ObjectsEntityGet200ResponseInner>())
         override suspend fun getProductGroups() = Result.success(listOf(
-            ObjectsEntityGet200ResponseInner(id = 4, name = "Lácteos"),
+            ObjectsEntityGet200ResponseInner(id = 4, name = "Despensa"),
         ))
         override suspend fun createProduct(body: ObjectsEntityGet200ResponseInner) = Result.success(1)
         override suspend fun getProducts() = Result.success(listOf(
-            ObjectsEntityGet200ResponseInner(id = 1, name = "Leche entera", productGroupId = 4, quIdStock = 3),
+            // Stock unit lata (6), purchase unit pack (3): the mismatch case from grocy.
+            ObjectsEntityGet200ResponseInner(id = 1, name = "P7", productGroupId = 4, quIdStock = 6, quIdPurchase = 3),
             ObjectsEntityGet200ResponseInner(id = 2, name = "Pan de molde"),
         ))
         override suspend fun getShoppingLocations() = Result.success(emptyList<ObjectsEntityGet200ResponseInner>())
     }
 
+    /** Stateful stub: created/updated/deleted rows are reflected by later [getItems] calls. */
     private class ShoppingListDataSourceStub(
         var lists: List<ObjectsEntityGet200ResponseInner> = listOf(ObjectsEntityGet200ResponseInner(id = 2)),
+        var missing: List<CurrentVolatilStockResponseMissingProductsInner> = emptyList(),
+        val items: MutableList<ObjectsEntityGet200ResponseInner> = mutableListOf(),
     ) : ShoppingListDataSource {
         var createdListName: String? = null
-        var missingProductsListId: Int? = null
         val doneCalls = mutableListOf<Pair<Int, Boolean>>()
-        val addedProducts = mutableListOf<Triple<Int, Int, Double>>()
         var itemFetches = 0
-        var items = listOf(
-            ObjectsEntityGet200ResponseInner(id = 10, productId = 1, amount = 5.0, quId = 3, shoppingListId = 2, done = 0),
-            ObjectsEntityGet200ResponseInner(id = 11, productId = 2, amount = 1.0, shoppingListId = 2, done = 1),
-            // Another list's row and a note-only row: both must be ignored.
-            ObjectsEntityGet200ResponseInner(id = 12, productId = 1, amount = 2.0, shoppingListId = 9, done = 0),
-            ObjectsEntityGet200ResponseInner(id = 13, note = "solo nota", shoppingListId = 2, done = 0),
-        )
+        private var nextId = 100
 
         override suspend fun getShoppingLists() = Result.success(lists)
 
@@ -53,7 +51,43 @@ class ShoppingListRepositoryImplTest {
 
         override suspend fun getItems(): Result<List<ObjectsEntityGet200ResponseInner>> {
             itemFetches++
-            return Result.success(items)
+            return Result.success(items.toList())
+        }
+
+        override suspend fun getMissingProducts() = Result.success(missing)
+
+        override suspend fun createItem(
+            listId: Int,
+            productId: Int,
+            amount: Double,
+            quId: Int?,
+            note: String?,
+        ): Result<Unit> {
+            items += ObjectsEntityGet200ResponseInner(
+                id = nextId++,
+                shoppingListId = listId,
+                productId = productId,
+                amount = amount,
+                quId = quId,
+                note = note,
+                done = 0,
+            )
+            return Result.success(Unit)
+        }
+
+        override suspend fun updateItem(
+            itemId: Int,
+            amount: Double,
+            quId: Int?,
+            note: String?,
+        ): Result<Unit> {
+            val index = items.indexOfFirst { it.id == itemId }
+            items[index] = items[index].copy(
+                amount = amount,
+                quId = quId ?: items[index].quId,
+                note = note ?: items[index].note,
+            )
+            return Result.success(Unit)
         }
 
         override suspend fun setDone(itemId: Int, done: Boolean): Result<Unit> {
@@ -61,41 +95,132 @@ class ShoppingListRepositoryImplTest {
             return Result.success(Unit)
         }
 
-        override suspend fun addMissingProducts(listId: Int): Result<Unit> {
-            missingProductsListId = listId
-            return Result.success(Unit)
-        }
-
-        override suspend fun addProduct(listId: Int, productId: Int, amount: Double): Result<Unit> {
-            addedProducts += Triple(listId, productId, amount)
+        override suspend fun deleteItem(itemId: Int): Result<Unit> {
+            items.removeAll { it.id == itemId }
             return Result.success(Unit)
         }
     }
 
+    private fun missing(productId: Int, amount: Double) =
+        CurrentVolatilStockResponseMissingProductsInner(id = productId, amountMissing = amount)
+
+    private fun autoRow(id: Int, productId: Int, amount: Double, quId: Int?, done: Int = 0) =
+        ObjectsEntityGet200ResponseInner(
+            id = id, shoppingListId = 2, productId = productId, amount = amount, quId = quId, done = done,
+        )
+
     @Test
-    fun `first collection syncs missing products and joins master data`() = runBlocking {
-        val stub = ShoppingListDataSourceStub()
+    fun `a deficit without a row is added in stock units and joined with master data`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(missing = listOf(missing(productId = 1, amount = 3.0)))
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
 
         val entries = repo.getShoppingList().first()
 
-        assertEquals(2, stub.missingProductsListId)
-        assertEquals(2, entries.size)
+        val entry = entries.single()
+        assertEquals("P7", entry.productName)
+        assertEquals("Despensa", entry.groupName)
+        assertEquals(3.0, entry.amount)
+        // Deficits are in stock units, so the row must carry the stock unit, not the purchase one.
+        assertEquals("lata", entry.unitName)
+        assertEquals("latas", entry.unitNamePlural)
+        assertFalse(entry.done)
+    }
 
-        val milk = entries.first { it.id == 10 }
-        assertEquals("Leche entera", milk.productName)
-        assertEquals("Lácteos", milk.groupName)
-        assertEquals(5.0, milk.amount)
-        assertEquals("brik", milk.unitName)
-        assertEquals("briks", milk.unitNamePlural)
-        assertFalse(milk.done)
+    @Test
+    fun `a satisfied row is removed on sync`() = runBlocking {
+        // The stale row grocy's add-missing-products leaves behind after a purchase.
+        val stub = ShoppingListDataSourceStub(
+            missing = emptyList(),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 3)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
 
-        val bread = entries.first { it.id == 11 }
-        assertEquals("Pan de molde", bread.productName)
-        assertEquals(null, bread.groupName)
-        // No qu_id on the row and no stock unit on the product: generic fallback names.
-        assertEquals("ud", bread.unitName)
-        assertTrue(bread.done)
+        val entries = repo.getShoppingList().first()
+
+        assertTrue(entries.isEmpty())
+        assertTrue(stub.items.isEmpty())
+    }
+
+    @Test
+    fun `a stale amount and purchase-unit stamp are corrected on sync`() = runBlocking {
+        // Row says 3 packs (grocy's unit mismatch); the real deficit is 1 lata.
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(missing(productId = 1, amount = 1.0)),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 3)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entry = repo.getShoppingList().first().single()
+
+        assertEquals(1.0, entry.amount)
+        assertEquals("lata", entry.unitName)
+    }
+
+    @Test
+    fun `manual rows are preserved and crossed-off manual rows are cleared on sync`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = emptyList(),
+            items = mutableListOf(
+                autoRow(id = 30, productId = 1, amount = 2.0, quId = 6).copy(note = "krocy:manual"),
+                autoRow(id = 31, productId = 2, amount = 1.0, quId = null, done = 1).copy(note = "krocy:manual"),
+            ),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entries = repo.getShoppingList().first()
+
+        // The pending manual row survives although its product has no deficit...
+        assertEquals(listOf(30), entries.map { it.id })
+        // ...and the crossed-off one was bought: cleared.
+        assertEquals(listOf(30), stub.items.map { it.id })
+    }
+
+    @Test
+    fun `a deficit for a manually listed product does not create a second row`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(missing(productId = 1, amount = 3.0)),
+            items = mutableListOf(
+                autoRow(id = 30, productId = 1, amount = 5.0, quId = 6).copy(note = "krocy:manual"),
+            ),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+
+        val entries = repo.getShoppingList().first()
+
+        val entry = entries.single()
+        assertEquals(30, entry.id)
+        assertEquals(5.0, entry.amount)
+    }
+
+    @Test
+    fun `manual add creates a marked row with the product's stock unit`() = runBlocking {
+        val stub = ShoppingListDataSourceStub()
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+        repo.getShoppingList().first()
+
+        repo.addProduct(productId = 1, amount = 2.0)
+
+        val row = stub.items.single()
+        assertEquals("krocy:manual", row.note)
+        assertEquals(6, row.quId)
+        assertEquals(2.0, row.amount)
+        assertEquals(2.0, repo.getShoppingList().first().single().amount)
+    }
+
+    @Test
+    fun `manual add merges into an existing row and claims it as manual`() = runBlocking {
+        val stub = ShoppingListDataSourceStub(
+            missing = listOf(missing(productId = 1, amount = 3.0)),
+            items = mutableListOf(autoRow(id = 21, productId = 1, amount = 3.0, quId = 6)),
+        )
+        val repo = ShoppingListRepositoryImpl(stub, genericStub)
+        repo.getShoppingList().first()
+
+        repo.addProduct(productId = 1, amount = 2.0)
+
+        val row = stub.items.single()
+        assertEquals(5.0, row.amount)
+        assertEquals("krocy:manual", row.note)
     }
 
     @Test
@@ -106,31 +231,35 @@ class ShoppingListRepositoryImplTest {
         repo.getShoppingList().first()
 
         assertEquals("Lista de la compra", stub.createdListName)
-        assertEquals(2, stub.missingProductsListId)
     }
 
     @Test
     fun `setDone updates the row and patches the cache without refetching`() = runBlocking {
-        val stub = ShoppingListDataSourceStub()
+        val stub = ShoppingListDataSourceStub(missing = listOf(missing(productId = 1, amount = 3.0)))
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
-        repo.getShoppingList().first()
+        val entryId = repo.getShoppingList().first().single().id
+        val fetchesAfterLoad = stub.itemFetches
 
-        repo.setDone(entryId = 10, done = true)
+        repo.setDone(entryId = entryId, done = true)
 
-        assertEquals(listOf(10 to true), stub.doneCalls)
-        assertTrue(repo.getShoppingList().first().first { it.id == 10 }.done)
-        assertEquals(1, stub.itemFetches)
+        assertEquals(listOf(entryId to true), stub.doneCalls)
+        assertTrue(repo.getShoppingList().first().single().done)
+        assertEquals(fetchesAfterLoad, stub.itemFetches)
     }
 
     @Test
-    fun `addProduct forwards the request and refreshes the list`() = runBlocking {
-        val stub = ShoppingListDataSourceStub()
+    fun `rows of other shopping lists are not touched`() = runBlocking {
+        val otherListRow = autoRow(id = 40, productId = 1, amount = 9.0, quId = 3)
+            .copy(shoppingListId = 7)
+        val stub = ShoppingListDataSourceStub(
+            missing = emptyList(),
+            items = mutableListOf(otherListRow),
+        )
         val repo = ShoppingListRepositoryImpl(stub, genericStub)
-        repo.getShoppingList().first()
 
-        repo.addProduct(productId = 2, amount = 3.0)
+        val entries = repo.getShoppingList().first()
 
-        assertEquals(listOf(Triple(2, 2, 3.0)), stub.addedProducts)
-        assertEquals(2, stub.itemFetches)
+        assertTrue(entries.isEmpty())
+        assertEquals(listOf(40), stub.items.map { it.id })
     }
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/shoppinglist/ShoppingListEntry.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/shoppinglist/ShoppingListEntry.kt
@@ -1,0 +1,17 @@
+package com.srfmolina.krocy.domain.model.shoppinglist
+
+/**
+ * One row of the shopping list, already joined with its product master data.
+ *
+ * @param groupName the product's group, or null when the product has no group assigned.
+ */
+data class ShoppingListEntry(
+    val id: Int,
+    val productId: Int,
+    val productName: String,
+    val groupName: String?,
+    val amount: Double,
+    val unitName: String,
+    val unitNamePlural: String,
+    val done: Boolean,
+)

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/ShoppingListRepository.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/ShoppingListRepository.kt
@@ -1,0 +1,14 @@
+package com.srfmolina.krocy.domain.repository
+
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import kotlinx.coroutines.flow.Flow
+
+interface ShoppingListRepository {
+    fun getShoppingList(): Flow<List<ShoppingListEntry>>
+
+    suspend fun setDone(entryId: Int, done: Boolean)
+
+    suspend fun addProduct(productId: Int, amount: Double)
+
+    suspend fun forceRefresh()
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/AddToShoppingListUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/AddToShoppingListUseCase.kt
@@ -1,0 +1,13 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist
+
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.model.AddToShoppingListUCRequest
+
+class AddToShoppingListUseCase(
+    private val repo: ShoppingListRepository
+) : ResultUseCase<AddToShoppingListUCRequest, Unit>() {
+
+    override suspend fun execute(params: AddToShoppingListUCRequest) =
+        repo.addProduct(params.productId, params.amount)
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/ObserveShoppingListUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/ObserveShoppingListUseCase.kt
@@ -1,0 +1,13 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist
+
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultFlowUseCaseNoParams
+import kotlinx.coroutines.flow.Flow
+
+class ObserveShoppingListUseCase(
+    private val repo: ShoppingListRepository
+) : ResultFlowUseCaseNoParams<List<ShoppingListEntry>>() {
+
+    override fun execute(): Flow<List<ShoppingListEntry>> = repo.getShoppingList()
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/RefreshShoppingListUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/RefreshShoppingListUseCase.kt
@@ -1,0 +1,10 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist
+
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCaseNoParams
+
+class RefreshShoppingListUseCase(
+    private val repo: ShoppingListRepository
+) : ResultUseCaseNoParams<Unit>() {
+    override suspend fun execute() = repo.forceRefresh()
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/SetEntryDoneUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/SetEntryDoneUseCase.kt
@@ -1,0 +1,13 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist
+
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.model.SetEntryDoneUCRequest
+
+class SetEntryDoneUseCase(
+    private val repo: ShoppingListRepository
+) : ResultUseCase<SetEntryDoneUCRequest, Unit>() {
+
+    override suspend fun execute(params: SetEntryDoneUCRequest) =
+        repo.setDone(params.entryId, params.done)
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/model/AddToShoppingListUCRequest.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/model/AddToShoppingListUCRequest.kt
@@ -1,0 +1,6 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist.model
+
+data class AddToShoppingListUCRequest(
+    val productId: Int,
+    val amount: Double
+)

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/model/SetEntryDoneUCRequest.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/shoppinglist/model/SetEntryDoneUCRequest.kt
@@ -1,0 +1,6 @@
+package com.srfmolina.krocy.domain.usecase.shoppinglist.model
+
+data class SetEntryDoneUCRequest(
+    val entryId: Int,
+    val done: Boolean
+)

--- a/grocy-client/SPEC-DEVIATIONS.md
+++ b/grocy-client/SPEC-DEVIATIONS.md
@@ -122,7 +122,10 @@ anything useful).
 
 **Workaround here:** hand-written
 `src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt`
-aliases all five names to the complete `ExposedEntity` enum. Protected via
+aliases four of the five names to the complete `ExposedEntity` enum.
+`ExposedEntityIncludingUserEntitiesNotIncludingNotEditable` deliberately stays on the
+inverted `ExposedEntityNoEdit`: its only consumer (`userfieldsEntityObjectIdPut`) is
+unused here — repoint it when userfields support lands. Protected via
 `.openapi-generator-ignore`.
 
 **Proposed upstream fix:** define those five schemas in `components/schemas` with the
@@ -141,6 +144,13 @@ Protected via `.openapi-generator-ignore`.
 
 **Proposed upstream fix:** add a `QuantityUnitConversion` schema and include its fields in
 the generic-entity response schema.
+
+## 6. Spec fails OpenAPI validation
+
+Generation requires `--skip-validate-spec` (the dangling `$ref`s of item 4 alone break
+validation).
+
+**Proposed upstream fix:** items 4–5; then validation can be re-enabled here.
 
 ## 7. `shopping_list` rows: server sends `done` and `qu_id`; spec omits both
 
@@ -164,14 +174,9 @@ uses it).
 `qu_id` via the recipe-position schema). Reads and the partial-body `PUT` both go through
 `ObjectsEntityGet200ResponseInner`; the client's `Json` leaves `encodeDefaults` off, so
 `ObjectsEntityGet200ResponseInner(done = 1)` encodes exactly `{"done":1}`.
-Regression guard: shopping-list case in
-`data/src/jvmTest/.../datasource/remote/generic/GenericEntityDeserializationTest.kt`.
+Regression guard: the shopping-list cases in
+`data/src/jvmTest/.../datasource/remote/generic/GenericEntityDeserializationTest.kt`
+cover `ObjectsEntityGet200ResponseInner` only. The `ShoppingListItem` additions are for
+spec fidelity — nothing in the app reads that model, and they are untested.
 
 **Proposed upstream fix:** add `done` (and `qu_id`) to the `ShoppingListItem` schema.
-
-## 6. Spec fails OpenAPI validation
-
-Generation requires `--skip-validate-spec` (the dangling `$ref`s of item 4 alone break
-validation).
-
-**Proposed upstream fix:** items 4–5; then validation can be re-enabled here.

--- a/grocy-client/SPEC-DEVIATIONS.md
+++ b/grocy-client/SPEC-DEVIATIONS.md
@@ -115,8 +115,10 @@ Path parameters `$ref` five schema names that do not exist in `components/schema
 
 The generator emits imports for the missing models, and the partial enums it does produce
 are wrong: `ExposedEntityNoEdit` lists the *non-editable* entities (so `objectsEntityPost`
-could not create products), and `ExposedEntityNoListing` contains only `api_keys` (so
-`objectsEntityGet` could not list anything useful).
+could not create products), `ExposedEntityNoDelete` lists the *non-deletable* ones (so
+`objectsEntityObjectIdDelete` could not delete shopping-list rows), and
+`ExposedEntityNoListing` contains only `api_keys` (so `objectsEntityGet` could not list
+anything useful).
 
 **Workaround here:** hand-written
 `src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt`

--- a/grocy-client/SPEC-DEVIATIONS.md
+++ b/grocy-client/SPEC-DEVIATIONS.md
@@ -140,6 +140,33 @@ Protected via `.openapi-generator-ignore`.
 **Proposed upstream fix:** add a `QuantityUnitConversion` schema and include its fields in
 the generic-entity response schema.
 
+## 7. `shopping_list` rows: server sends `done` and `qu_id`; spec omits both
+
+The `ShoppingListItem` schema (and therefore the merged generic-entity response schema)
+declares only `id`, `shopping_list_id`, `product_id`, `note`, `amount`,
+`row_created_timestamp` and `userfields` — but the server includes two more columns on
+every row, and `done` is the only way to persist a crossed-off state (the grocy web UI
+uses it).
+
+**Evidence (demo server, 2026-07-09):**
+- `GET /api/objects/shopping_list` → rows include `"done": 0` and `"qu_id": 3`
+  (after `POST /api/stock/shoppinglist/add-missing-products`).
+- `PUT /api/objects/shopping_list/{id}` with body `{"done":1}` → 204, and the row
+  reads back `"done": 1` — the round-trip the shopping list screen relies on.
+
+`done` is serialized as a `0`/`1` integer (DB-backed boolean, consistent with item 1).
+
+**Workarounds here:** sed post-fixes in `regenerate.sh` add
+`done: kotlin.Int?` to `ObjectsEntityGet200ResponseInner` and `ShoppingListItem`, and
+`quId: kotlin.Int?` to `ShoppingListItem` (`ObjectsEntityGet200ResponseInner` already has
+`qu_id` via the recipe-position schema). Reads and the partial-body `PUT` both go through
+`ObjectsEntityGet200ResponseInner`; the client's `Json` leaves `encodeDefaults` off, so
+`ObjectsEntityGet200ResponseInner(done = 1)` encodes exactly `{"done":1}`.
+Regression guard: shopping-list case in
+`data/src/jvmTest/.../datasource/remote/generic/GenericEntityDeserializationTest.kt`.
+
+**Proposed upstream fix:** add `done` (and `qu_id`) to the `ShoppingListItem` schema.
+
 ## 6. Spec fails OpenAPI validation
 
 Generation requires `--skip-validate-spec` (the dangling `$ref`s of item 4 alone break

--- a/grocy-client/regenerate.sh
+++ b/grocy-client/regenerate.sh
@@ -56,6 +56,14 @@ echo ">>> Fixing has_childs type (boolean→Int mapping breaks: the server sends
 find "$SCRIPT_DIR/src/commonMain" -name "*.kt" -exec \
   sed -i 's|^    @SerialName(value = "has_childs") val hasChilds: kotlin\.Int? = null|    // Manually corrected (see regenerate.sh): the boolean→Int mapping breaks here, the server sends true/false\n    @SerialName(value = "has_childs") val hasChilds: kotlinx.serialization.json.JsonElement? = null|' {} +
 
+echo ">>> Adding done to shopping_list models (spec omits it; the server sends it as 0/1)..."
+find "$SCRIPT_DIR/src/commonMain" -name "*.kt" -exec \
+  sed -i 's|^    @SerialName(value = "shopping_list_id") val shoppingListId: kotlin\.Int? = null,$|    @SerialName(value = "shopping_list_id") val shoppingListId: kotlin.Int? = null,\n\n    // Manually added (see regenerate.sh): spec omits done on shopping_list rows, the server sends it as 0/1\n    @SerialName(value = "done") val done: kotlin.Int? = null,|' {} +
+
+echo ">>> Adding qu_id to ShoppingListItem (spec omits it; ObjectsEntityGet200ResponseInner already has it)..."
+sed -i 's|^    @SerialName(value = "done") val done: kotlin\.Int? = null,$|    @SerialName(value = "done") val done: kotlin.Int? = null,\n\n    // Manually added (see regenerate.sh): spec omits qu_id on shopping_list rows, the server sends it\n    @SerialName(value = "qu_id") val quId: kotlin.Int? = null,|' \
+  "$SCRIPT_DIR/src/commonMain/kotlin/org/openapitools/client/models/ShoppingListItem.kt"
+
 echo ">>> Restoring custom files..."
 cp -r "$PROTECTED_DIR/." "$SCRIPT_DIR/"
 rm -rf "$PROTECTED_DIR"

--- a/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt
+++ b/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ExposedEntityTypeAliases.kt
@@ -5,7 +5,10 @@ package org.openapitools.client.models
 // These typealiases bridge the generated API code to the actual enum classes that exist.
 typealias ExposedEntityIncludingUserEntities = ExposedEntity
 typealias ExposedEntityIncludingUserEntitiesNotIncludingNotEditable = ExposedEntityNoEdit
-typealias ExposedEntityNotIncludingNotDeletable = ExposedEntityNoDelete
+// The generated ExposedEntityNoDelete enum is inverted like ExposedEntityNoEdit below: it lists
+// the *non-deletable* entities (stock, logs, views, ...), so objectsEntityObjectIdDelete couldn't
+// name a deletable entity like shopping_list. Point this alias at the full ExposedEntity enum.
+typealias ExposedEntityNotIncludingNotDeletable = ExposedEntity
 // The generated ExposedEntityNoEdit enum is inverted: it lists the *non-editable* entities
 // (stock, api_keys, views, ...) and has no `products`, so objectsEntityPost/Put couldn't create
 // or edit editable entities. Point this alias at the full ExposedEntity enum (which has every

--- a/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ObjectsEntityGet200ResponseInner.kt
+++ b/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ObjectsEntityGet200ResponseInner.kt
@@ -165,6 +165,9 @@ data class ObjectsEntityGet200ResponseInner (
 
     @SerialName(value = "shopping_list_id") val shoppingListId: kotlin.Int? = null,
 
+    // Manually added (see regenerate.sh): spec omits done on shopping_list rows, the server sends it as 0/1
+    @SerialName(value = "done") val done: kotlin.Int? = null,
+
     @SerialName(value = "product_id") val productId: kotlin.Int? = null,
 
     @SerialName(value = "note") val note: kotlin.String? = null,

--- a/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ShoppingListItem.kt
+++ b/grocy-client/src/commonMain/kotlin/org/openapitools/client/models/ShoppingListItem.kt
@@ -46,6 +46,12 @@ data class ShoppingListItem (
 
     @SerialName(value = "shopping_list_id") val shoppingListId: kotlin.Int? = null,
 
+    // Manually added (see regenerate.sh): spec omits done on shopping_list rows, the server sends it as 0/1
+    @SerialName(value = "done") val done: kotlin.Int? = null,
+
+    // Manually added (see regenerate.sh): spec omits qu_id on shopping_list rows, the server sends it
+    @SerialName(value = "qu_id") val quId: kotlin.Int? = null,
+
     @SerialName(value = "product_id") val productId: kotlin.Int? = null,
 
     @SerialName(value = "note") val note: kotlin.String? = null,

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/App.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/App.kt
@@ -26,9 +26,11 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.srfmolina.krocy.ui.AppViewModel.Effect
 import com.srfmolina.krocy.ui.AppViewModel.Event
+import com.srfmolina.krocy.ui.presentation.common.KrocyDialog
 import com.srfmolina.krocy.ui.presentation.common.KrocyFabMenu
 import com.srfmolina.krocy.ui.presentation.common.KrocySnackbar
 import com.srfmolina.krocy.ui.presentation.common.KrocySnackbarVisuals
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.SnackbarConfigurationUi
 import com.srfmolina.krocy.ui.presentation.feature.welcome.navigation.navigateToWelcome
@@ -115,6 +117,9 @@ fun App() {
                     onChangeFab = { config ->
                         viewModel.launchEvent(Event.OnFabChange(config))
                     },
+                    onChangeDialog = { config ->
+                        viewModel.launchEvent(Event.OnDialogChange(config))
+                    },
                     onShowSnackbar = onShowSnackbar
                 )
             }
@@ -130,6 +135,9 @@ fun App() {
                 },
                 onChangeFab = { config ->
                     viewModel.launchEvent(Event.OnFabChange(config))
+                },
+                onChangeDialog = { config ->
+                    viewModel.launchEvent(Event.OnDialogChange(config))
                 },
                 onShowSnackbar = onShowSnackbar
             )
@@ -147,6 +155,7 @@ private fun MainContent(
     onOpenNavRail: () -> Unit,
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
     onChangeFab: (FabConfigurationUi) -> Unit,
+    onChangeDialog: (DialogConfigurationUi?) -> Unit,
     onShowSnackbar: (SnackbarConfigurationUi) -> Unit
 ) {
     Scaffold(
@@ -196,6 +205,7 @@ private fun MainContent(
                 navController = navController,
                 onChangeTopBar = onChangeTopBar,
                 onChangeFab = onChangeFab,
+                onChangeDialog = onChangeDialog,
                 onOpenNavRail = onOpenNavRail,
                 onShowSnackbar = onShowSnackbar
             )
@@ -209,6 +219,8 @@ private fun MainContent(
                     actions = it.actions
                 )
             }
+
+            state.dialogConfig?.let { KrocyDialog(it) }
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/AppViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/AppViewModel.kt
@@ -7,6 +7,7 @@ import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
 import com.srfmolina.krocy.ui.base.UiEvent
 import com.srfmolina.krocy.ui.base.UiState
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
 
@@ -17,6 +18,7 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
         data class OnTopBarChange(val config: TopBarConfigurationUi) : Event
         data class OnChangeNavRailStatus(val open: Boolean) : Event
         data class OnFabChange(val config: FabConfigurationUi) : Event
+        data class OnDialogChange(val config: DialogConfigurationUi?) : Event
     }
 
     sealed interface Effect : UiEffect {
@@ -27,7 +29,8 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
         val isLoading: Boolean = true,
         val isNavRailOpen: Boolean = false,
         val topBarConfig: TopBarConfigurationUi? = null,
-        val fabConfig: FabConfigurationUi? = null
+        val fabConfig: FabConfigurationUi? = null,
+        val dialogConfig: DialogConfigurationUi? = null
     ) : UiState
 
     override fun createInitialState(): State = State()
@@ -38,6 +41,7 @@ internal class AppViewModel : BaseViewModel<Event, State, Effect>() {
             is Event.OnTopBarChange -> setState { copy(topBarConfig = event.config) }
             is Event.OnChangeNavRailStatus -> setState { copy(isNavRailOpen = event.open) }
             is Event.OnFabChange -> setState { copy(fabConfig = event.config) }
+            is Event.OnDialogChange -> setState { copy(dialogConfig = event.config) }
         }
     }
 

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
@@ -9,6 +9,10 @@ import com.srfmolina.krocy.domain.usecase.product.CreateProductUseCase
 import com.srfmolina.krocy.domain.usecase.product.CreateQuConversionUseCase
 import com.srfmolina.krocy.domain.usecase.product.GetProductPurchaseInfoUseCase
 import com.srfmolina.krocy.domain.usecase.product.GetProductsUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.AddToShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.ObserveShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.RefreshShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.SetEntryDoneUseCase
 import com.srfmolina.krocy.domain.usecase.stock.AddStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ConsumeStockUseCase
 import com.srfmolina.krocy.domain.usecase.stock.ObserveStockUseCase
@@ -18,6 +22,7 @@ import com.srfmolina.krocy.domain.usecase.stock.RefreshStockUseCase
 import com.srfmolina.krocy.ui.AppViewModel
 import com.srfmolina.krocy.ui.presentation.feature.creation.CreateProductViewModel
 import com.srfmolina.krocy.ui.presentation.feature.purchase.PurchaseViewModel
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel
 import com.srfmolina.krocy.ui.presentation.feature.stock.StockViewModel
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
@@ -39,9 +44,14 @@ val uiModule = module {
     singleOf(::GetProductsUseCase)
     singleOf(::GetProductPurchaseInfoUseCase)
     singleOf(::GetShoppingLocationsUseCase)
+    singleOf(::ObserveShoppingListUseCase)
+    singleOf(::RefreshShoppingListUseCase)
+    singleOf(::SetEntryDoneUseCase)
+    singleOf(::AddToShoppingListUseCase)
 
     viewModelOf(::AppViewModel)
     viewModelOf(::StockViewModel)
     viewModelOf(::CreateProductViewModel)
     viewModelOf(::PurchaseViewModel)
+    viewModelOf(::ShoppingListViewModel)
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyDialog.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyDialog.kt
@@ -1,0 +1,30 @@
+package com.srfmolina.krocy.ui.presentation.common
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
+
+/** Renders the app-level [DialogConfigurationUi]; see that class for the convention. */
+@Composable
+internal fun KrocyDialog(config: DialogConfigurationUi) {
+    AlertDialog(
+        onDismissRequest = config.dismiss.onClick,
+        title = { Text(config.title) },
+        text = { config.content() },
+        confirmButton = {
+            TextButton(
+                onClick = config.confirm.onClick,
+                enabled = config.confirmEnabled,
+            ) {
+                Text(config.confirm.label)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = config.dismiss.onClick) {
+                Text(config.dismiss.label)
+            }
+        },
+    )
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyFabMenu.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/KrocyFabMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonMenu
 import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.Icon
@@ -48,6 +49,9 @@ import com.srfmolina.krocy.ui.presentation.theme.spacing
  * of [actions]. Each action is described by a [LabeledActionUi]; tapping one closes the menu and
  * invokes its `onClick`.
  *
+ * A single action skips the menu entirely: the FAB shows the action's own icon and pressing it
+ * triggers the action directly.
+ *
  * @param actions the menu entries, rendered top-to-bottom above the toggle button.
  * @param visible whether the collapsed FAB should be shown. The button stays visible while the menu
  *   is expanded regardless of this flag (e.g. to keep it on screen while the list is scrolled).
@@ -59,6 +63,11 @@ internal fun KrocyFabMenu(
     modifier: Modifier = Modifier,
     visible: Boolean = true,
 ) {
+    if (actions.size == 1) {
+        SingleActionFab(action = actions.first(), visible = visible, modifier = modifier)
+        return
+    }
+
     var expanded by rememberSaveable { mutableStateOf(false) }
 
     FloatingActionButtonMenu(
@@ -121,6 +130,28 @@ internal fun KrocyFabMenu(
                 },
                 text = { Text(action.label) }
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun SingleActionFab(
+    action: LabeledActionUi,
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    FloatingActionButton(
+        onClick = action.onClick,
+        modifier = modifier
+            .semantics { contentDescription = action.contentDescription }
+            .animateFloatingActionButton(
+                visible = visible,
+                alignment = Alignment.BottomEnd
+            ),
+    ) {
+        action.icon?.let { icon ->
+            Icon(imageVector = icon, contentDescription = null)
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/DialogConfigurationUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/model/DialogConfigurationUi.kt
@@ -1,0 +1,19 @@
+package com.srfmolina.krocy.ui.presentation.common.model
+
+import androidx.compose.runtime.Composable
+
+/**
+ * App-hosted modal dialog, following the top bar / FAB / snackbar convention: the feature
+ * screen submits a configuration (and `null` to dismiss); the app scaffold renders it.
+ *
+ * [content] is the dialog body. Screens that need live form state should read their own
+ * ViewModel inside the slot instead of capturing snapshots, and re-submit the configuration
+ * only when [confirmEnabled] changes.
+ */
+internal data class DialogConfigurationUi(
+    val title: String,
+    val confirm: LabeledActionUi,
+    val dismiss: LabeledActionUi,
+    val confirmEnabled: Boolean = true,
+    val content: @Composable () -> Unit,
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
@@ -1,0 +1,464 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
+import com.srfmolina.krocy.ui.presentation.common.model.IconActionUi
+import com.srfmolina.krocy.ui.presentation.common.model.LabeledActionUi
+import com.srfmolina.krocy.ui.presentation.common.model.SnackbarConfigurationUi
+import com.srfmolina.krocy.ui.presentation.common.model.SnackbarTypeUi
+import com.srfmolina.krocy.ui.presentation.common.selector.SearchableOptionSelector
+import com.srfmolina.krocy.ui.presentation.common.skeleton.ProvideSkeleton
+import com.srfmolina.krocy.ui.presentation.common.skeleton.SkeletonTransitionAnimation
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Effect
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Event
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.component.ShoppingGroupCard
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingGroupUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingListEntryUi
+import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
+import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarTypeUi
+import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.isCompact
+import com.srfmolina.krocy.ui.presentation.theme.spacing
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun ShoppingListScreen(
+    onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
+    onChangeDialog: (DialogConfigurationUi?) -> Unit,
+    onOpenNavRail: () -> Unit,
+    onShowSnackbar: (SnackbarConfigurationUi) -> Unit,
+) {
+    val viewModel: ShoppingListViewModel = koinViewModel()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+    val gridState = rememberLazyStaggeredGridState()
+    val isCompact = MaterialTheme.isCompact
+    val fabVisible by remember(isCompact) {
+        derivedStateOf {
+            if (isCompact) {
+                listState.firstVisibleItemIndex == 0 || !listState.canScrollForward
+            } else {
+                gridState.firstVisibleItemIndex == 0 || !gridState.canScrollForward
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        onChangeTopBar(TopBarConfigurationUi(
+            title = "Lista de la compra",
+            type = TopBarTypeUi.SMALL,
+            leadingAction = IconActionUi(
+                icon = Icons.Filled.Menu,
+                contentDescription = "Abrir menú de navegación",
+                onClick = onOpenNavRail
+            ),
+            trailingAction = IconActionUi(
+                icon = Icons.Filled.Refresh,
+                contentDescription = "Actualizar la lista",
+                onClick = { viewModel.launchEvent(Event.OnRefresh) }
+            )
+        ))
+        viewModel.launchEvent(Event.Init)
+    }
+
+    LaunchedEffect(state.isLoading, state.loadError, fabVisible) {
+        onChangeFab(FabConfigurationUi(
+            isVisible = !state.isLoading && !state.loadError && fabVisible,
+            actions = listOf(
+                LabeledActionUi(
+                    label = "Añadir a la lista",
+                    contentDescription = "Añadir un producto a la lista",
+                    icon = Icons.Filled.Add,
+                    onClick = { viewModel.launchEvent(Event.OnOpenAddDialog) }
+                )
+            )
+        ))
+    }
+
+    // The dialog content reads the ViewModel itself, so the configuration only needs to be
+    // re-submitted when visibility or the confirm button's enabled state changes.
+    val dialogVisible = state.addDialog != null
+    val dialogConfirmEnabled = state.addDialog?.let { it.isValid && !it.isSubmitting } == true
+    LaunchedEffect(dialogVisible, dialogConfirmEnabled) {
+        onChangeDialog(
+            if (!dialogVisible) {
+                null
+            } else {
+                DialogConfigurationUi(
+                    title = "Añadir a la lista",
+                    confirmEnabled = dialogConfirmEnabled,
+                    confirm = LabeledActionUi(
+                        label = "Añadir",
+                        contentDescription = "Añadir el producto a la lista",
+                        onClick = { viewModel.launchEvent(Event.OnAddSubmit) }
+                    ),
+                    dismiss = LabeledActionUi(
+                        label = "Cancelar",
+                        contentDescription = "Cerrar sin añadir",
+                        onClick = { viewModel.launchEvent(Event.OnDismissAddDialog) }
+                    ),
+                    content = { AddToShoppingListDialogContent(viewModel) },
+                )
+            }
+        )
+    }
+
+    // The dialog belongs to this screen: clear it when navigating away, since unlike the
+    // top bar and FAB no later screen overwrites it.
+    DisposableEffect(Unit) {
+        onDispose { onChangeDialog(null) }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is Effect.ProductAdded -> onShowSnackbar(
+                    SnackbarConfigurationUi(message = "Añadido a la lista: «${effect.productName}»")
+                )
+                is Effect.ShowError -> onShowSnackbar(
+                    SnackbarConfigurationUi(message = effect.message, type = SnackbarTypeUi.ERROR)
+                )
+            }
+        }
+    }
+
+    ShoppingListScreen(
+        isLoading = state.isLoading,
+        loadError = state.loadError,
+        groups = state.groups,
+        listState = listState,
+        gridState = gridState,
+        onToggleDone = { entryId -> viewModel.launchEvent(Event.OnToggleDone(entryId)) },
+        onRetry = { viewModel.launchEvent(Event.OnRefresh) },
+    )
+}
+
+@Composable
+private fun ShoppingListScreen(
+    isLoading: Boolean,
+    loadError: Boolean,
+    groups: List<ShoppingGroupUi>,
+    listState: LazyListState,
+    gridState: LazyStaggeredGridState,
+    onToggleDone: (Int) -> Unit,
+    onRetry: () -> Unit,
+) {
+    SkeletonTransitionAnimation(
+        isLoading = isLoading
+    ) { loading ->
+        when {
+            loading -> ProvideSkeleton(active = true) {
+                ShoppingListGroups(groups = skeletonPlaceholders, onToggleDone = {})
+            }
+            loadError -> LoadError(onRetry = onRetry)
+            groups.isEmpty() -> EmptyShoppingList()
+            else -> ShoppingListGroups(
+                groups = groups,
+                onToggleDone = onToggleDone,
+                listState = listState,
+                gridState = gridState,
+                contentPadding = PaddingValues(
+                    top = MaterialTheme.spacing.s2,
+                    bottom = MaterialTheme.spacing.s28,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShoppingListGroups(
+    groups: List<ShoppingGroupUi>,
+    onToggleDone: (Int) -> Unit,
+    listState: LazyListState = rememberLazyListState(),
+    gridState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
+    contentPadding: PaddingValues = PaddingValues(),
+) {
+    if (MaterialTheme.isCompact) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.s4),
+            contentPadding = contentPadding,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s6)
+        ) {
+            items(groups, key = { it.displayName }) { group ->
+                ShoppingGroupCard(
+                    group = group,
+                    onToggleDone = onToggleDone,
+                    modifier = Modifier.animateItem(),
+                )
+            }
+        }
+    } else {
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Adaptive(288.dp),
+            state = gridState,
+            modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.s4),
+            contentPadding = contentPadding,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4),
+            verticalItemSpacing = MaterialTheme.spacing.s4,
+        ) {
+            items(groups, key = { it.displayName }) { group ->
+                ShoppingGroupCard(
+                    group = group,
+                    onToggleDone = onToggleDone,
+                    modifier = Modifier.animateItem(),
+                )
+            }
+        }
+    }
+}
+
+/** An empty shopping list is success, not absence: everything is at its minimum stock. */
+@Composable
+private fun EmptyShoppingList() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
+            modifier = Modifier.padding(MaterialTheme.spacing.s6),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.CheckCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(MaterialTheme.spacing.s12),
+            )
+            Text(
+                text = "Todo en stock",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Text(
+                text = "Pulsa + para añadir algo extra a la lista",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LoadError(onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4),
+            modifier = Modifier.padding(MaterialTheme.spacing.s6),
+        ) {
+            Text(
+                text = "No se pudo cargar la lista de la compra.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            OutlinedButton(shapes = ButtonDefaults.shapes(), onClick = onRetry) {
+                Text("Reintentar")
+            }
+        }
+    }
+}
+
+/** Body of the app-hosted add dialog; reads the ViewModel directly so the form stays live. */
+@Composable
+private fun AddToShoppingListDialogContent(viewModel: ShoppingListViewModel) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val dialog = state.addDialog ?: return
+
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4)) {
+        SearchableOptionSelector(
+            label = "Producto",
+            options = dialog.products,
+            selectedId = dialog.selectedProductId,
+            onOptionSelected = { viewModel.launchEvent(Event.OnAddProductSelected(it)) },
+            required = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (dialog.products.isError) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s3),
+            ) {
+                Text(
+                    text = "No se pudieron cargar los productos.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { viewModel.launchEvent(Event.OnRetryLoadProducts) }) {
+                    Text("Reintentar")
+                }
+            }
+        }
+        val showAmountError = dialog.amount.isNotBlank() && !dialog.amountValid
+        OutlinedTextField(
+            value = dialog.amount,
+            onValueChange = { viewModel.launchEvent(Event.OnAddAmountChange(it)) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Cantidad *") },
+            singleLine = true,
+            isError = showAmountError,
+            supportingText = if (showAmountError) {
+                { Text("Número no válido") }
+            } else {
+                null
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        )
+    }
+}
+
+/**
+ * Representative dummy groups used only to drive the loading skeleton's layout (varied group
+ * sizes and name lengths), so the placeholder matches the real list's shape.
+ */
+private val skeletonPlaceholders: List<ShoppingGroupUi> = listOf(
+    ShoppingGroupUi(
+        name = "Frutas y verduras",
+        entries = listOf(
+            ShoppingListEntryUi(0, "Manzanas", "4 uds", done = false),
+            ShoppingListEntryUi(1, "Plátanos", "1 racimo", done = false),
+            ShoppingListEntryUi(2, "Tomates", "6 uds", done = false),
+        ),
+    ),
+    ShoppingGroupUi(
+        name = "Lácteos",
+        entries = listOf(
+            ShoppingListEntryUi(3, "Leche entera", "3 briks", done = false),
+            ShoppingListEntryUi(4, "Yogur natural", "8 uds", done = false),
+        ),
+    ),
+    ShoppingGroupUi(
+        name = "Despensa",
+        entries = listOf(
+            ShoppingListEntryUi(5, "Arroz", "1 paquete", done = false),
+            ShoppingListEntryUi(6, "Aceite de oliva", "1 botella", done = false),
+        ),
+    ),
+)
+
+// PREVIEW //
+
+@PreviewLightDark
+@Composable
+private fun ShoppingListScreenPreview() {
+    KrocyTheme {
+        Surface {
+            ShoppingListScreen(
+                isLoading = false,
+                loadError = false,
+                groups = listOf(
+                    ShoppingGroupUi(
+                        name = "Frutas y verduras",
+                        entries = listOf(
+                            ShoppingListEntryUi(1, "Manzanas", "4 uds", done = false),
+                            ShoppingListEntryUi(2, "Plátanos", "1 racimo", done = true),
+                            ShoppingListEntryUi(3, "Tomates", "6 uds", done = false),
+                        ),
+                    ),
+                    ShoppingGroupUi(
+                        name = "Lácteos",
+                        entries = listOf(
+                            ShoppingListEntryUi(4, "Leche entera", "3 briks", done = false),
+                            ShoppingListEntryUi(5, "Yogur natural", "8 uds", done = false),
+                        ),
+                    ),
+                    ShoppingGroupUi(
+                        name = null,
+                        entries = listOf(
+                            ShoppingListEntryUi(6, "Pan de molde", "1 paquete", done = false),
+                        ),
+                    ),
+                ),
+                listState = rememberLazyListState(),
+                gridState = rememberLazyStaggeredGridState(),
+                onToggleDone = {},
+                onRetry = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ShoppingListScreenEmptyPreview() {
+    KrocyTheme {
+        Surface {
+            ShoppingListScreen(
+                isLoading = false,
+                loadError = false,
+                groups = emptyList(),
+                listState = rememberLazyListState(),
+                gridState = rememberLazyStaggeredGridState(),
+                onToggleDone = {},
+                onRetry = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ShoppingListScreenSkeletonPreview() {
+    KrocyTheme {
+        Surface {
+            ShoppingListScreen(
+                isLoading = true,
+                loadError = false,
+                groups = emptyList(),
+                listState = rememberLazyListState(),
+                gridState = rememberLazyStaggeredGridState(),
+                onToggleDone = {},
+                onRetry = {},
+            )
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
@@ -228,7 +228,7 @@ private fun ShoppingListGroups(
             contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s6)
         ) {
-            items(groups, key = { it.displayName }) { group ->
+            items(groups, key = { it.key }) { group ->
                 ShoppingGroupCard(
                     group = group,
                     onToggleDone = onToggleDone,
@@ -245,7 +245,7 @@ private fun ShoppingListGroups(
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s4),
             verticalItemSpacing = MaterialTheme.spacing.s4,
         ) {
-            items(groups, key = { it.displayName }) { group ->
+            items(groups, key = { it.key }) { group ->
                 ShoppingGroupCard(
                     group = group,
                     onToggleDone = onToggleDone,

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListScreen.kt
@@ -125,7 +125,7 @@ internal fun ShoppingListScreen(
     // The dialog content reads the ViewModel itself, so the configuration only needs to be
     // re-submitted when visibility or the confirm button's enabled state changes.
     val dialogVisible = state.addDialog != null
-    val dialogConfirmEnabled = state.addDialog?.let { it.isValid && !it.isSubmitting } == true
+    val dialogConfirmEnabled = state.addDialog?.isValid == true
     LaunchedEffect(dialogVisible, dialogConfirmEnabled) {
         onChangeDialog(
             if (!dialogVisible) {

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
@@ -24,7 +24,6 @@ import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingGr
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.sync.Mutex
 
 internal class ShoppingListViewModel(
     private val observeShoppingListUseCase: ObserveShoppingListUseCase,
@@ -34,7 +33,6 @@ internal class ShoppingListViewModel(
     private val getProductsUseCase: GetProductsUseCase,
 ) : BaseViewModel<Event, State, Effect>() {
 
-    private val submitLock = Mutex()
     private var observeJob: Job? = null
 
     sealed interface Event : UiEvent {
@@ -149,36 +147,32 @@ internal class ShoppingListViewModel(
     }
 
     private suspend fun submitAdd() {
+        // Nulling the dialog before any suspension point makes this idempotent: a second
+        // OnAddSubmit dispatched before recomposition disables the button bounces off this
+        // null check, because events run on the confined main dispatcher.
         val dialog = currentState.addDialog ?: return
         if (!dialog.isValid) return
         val productName = dialog.selectedProductName ?: return
 
-        // Events are not serialized (each runs in its own coroutine), so a second OnAddSubmit
-        // dispatched before recomposition disables the button must be rejected here.
-        if (!submitLock.tryLock()) return
-        try {
-            // The dialog closes right away; the screen shows the loading skeleton until the
-            // repository's post-add refresh lands in the observed cache.
-            setState { copy(addDialog = null, isLoading = true) }
-            addToShoppingListUseCase(
-                AddToShoppingListUCRequest(
-                    productId = dialog.selectedProductId!!,
-                    amount = dialog.amount.toDouble(),
-                )
-            ).fold(
-                onSuccess = {
-                    // observe() normally cleared this already when the refreshed cache emitted;
-                    // this covers an emission deduped by the StateFlow.
-                    setState { copy(isLoading = false) }
-                    launchEffect(Effect.ProductAdded(productName))
-                },
-                onFailure = {
-                    setState { copy(isLoading = false) }
-                    launchEffect(Effect.ShowError("No se pudo añadir el producto"))
-                },
+        // The dialog closes right away; the screen shows the loading skeleton until the
+        // repository's post-add refresh lands in the observed cache.
+        setState { copy(addDialog = null, isLoading = true) }
+        addToShoppingListUseCase(
+            AddToShoppingListUCRequest(
+                productId = dialog.selectedProductId!!,
+                amount = dialog.amount.toDouble(),
             )
-        } finally {
-            submitLock.unlock()
-        }
+        ).fold(
+            onSuccess = {
+                // observe() normally cleared this already when the refreshed cache emitted;
+                // this covers an emission deduped by the StateFlow.
+                setState { copy(isLoading = false) }
+                launchEffect(Effect.ProductAdded(productName))
+            },
+            onFailure = {
+                setState { copy(isLoading = false) }
+                launchEffect(Effect.ShowError("No se pudo añadir el producto"))
+            },
+        )
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
@@ -1,0 +1,181 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist
+
+import androidx.lifecycle.viewModelScope
+import com.srfmolina.krocy.domain.usecase.product.GetProductsUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.AddToShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.ObserveShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.RefreshShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.SetEntryDoneUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.model.AddToShoppingListUCRequest
+import com.srfmolina.krocy.domain.usecase.shoppinglist.model.SetEntryDoneUCRequest
+import com.srfmolina.krocy.ui.base.BaseViewModel
+import com.srfmolina.krocy.ui.base.UiEffect
+import com.srfmolina.krocy.ui.base.UiEvent
+import com.srfmolina.krocy.ui.base.UiState
+import com.srfmolina.krocy.ui.presentation.common.mapper.toOption
+import com.srfmolina.krocy.ui.presentation.common.model.OptionsUi
+import com.srfmolina.krocy.ui.presentation.common.model.toOptionsUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Effect
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Event
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.State
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.mapper.toUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.mapper.withEntryDone
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingGroupUi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+
+internal class ShoppingListViewModel(
+    private val observeShoppingListUseCase: ObserveShoppingListUseCase,
+    private val refreshShoppingListUseCase: RefreshShoppingListUseCase,
+    private val setEntryDoneUseCase: SetEntryDoneUseCase,
+    private val addToShoppingListUseCase: AddToShoppingListUseCase,
+    private val getProductsUseCase: GetProductsUseCase,
+) : BaseViewModel<Event, State, Effect>() {
+
+    private val submitLock = Mutex()
+    private var observeJob: Job? = null
+
+    sealed interface Event : UiEvent {
+        data object Init : Event
+        data object OnRefresh : Event
+        data class OnToggleDone(val entryId: Int) : Event
+        data object OnOpenAddDialog : Event
+        data object OnDismissAddDialog : Event
+        data object OnRetryLoadProducts : Event
+        data class OnAddProductSelected(val id: Int?) : Event
+        data class OnAddAmountChange(val value: String) : Event
+        data object OnAddSubmit : Event
+    }
+
+    sealed interface Effect : UiEffect {
+        data class ProductAdded(val productName: String) : Effect
+        data class ShowError(val message: String) : Effect
+    }
+
+    /** Form state of the app-hosted "add to list" dialog; null while the dialog is hidden. */
+    data class AddDialogUi(
+        val products: OptionsUi = OptionsUi(),
+        val selectedProductId: Int? = null,
+        val amount: String = "1",
+        val isSubmitting: Boolean = false,
+    ) {
+        val amountValid: Boolean
+            get() = amount.toDoubleOrNull()?.let { it > 0.0 } == true
+
+        val isValid: Boolean
+            get() = selectedProductId != null && amountValid
+
+        val selectedProductName: String?
+            get() = products.options.firstOrNull { it.id == selectedProductId }?.label
+    }
+
+    data class State(
+        val isLoading: Boolean = true,
+        val loadError: Boolean = false,
+        val groups: List<ShoppingGroupUi> = emptyList(),
+        val addDialog: AddDialogUi? = null,
+    ) : UiState
+
+    override fun createInitialState(): State = State()
+
+    override suspend fun handleEvent(event: Event) {
+        when (event) {
+            is Event.Init -> observe()
+            is Event.OnRefresh -> refresh()
+            is Event.OnToggleDone -> toggleDone(event.entryId)
+            is Event.OnOpenAddDialog -> openAddDialog()
+            is Event.OnDismissAddDialog -> setState { copy(addDialog = null) }
+            is Event.OnRetryLoadProducts -> loadDialogProducts()
+            is Event.OnAddProductSelected -> setState {
+                copy(addDialog = addDialog?.copy(selectedProductId = event.id))
+            }
+            is Event.OnAddAmountChange -> setState {
+                copy(addDialog = addDialog?.copy(amount = event.value))
+            }
+            is Event.OnAddSubmit -> submitAdd()
+        }
+    }
+
+    private fun observe() {
+        observeJob?.cancel()
+        observeJob = observeShoppingListUseCase().onEach { result ->
+            result.onSuccess { entries ->
+                setState { copy(isLoading = false, loadError = false, groups = entries.toUi()) }
+            }.onFailure {
+                setState { copy(isLoading = false, loadError = true) }
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    private suspend fun refresh() {
+        setState { copy(isLoading = true, loadError = false) }
+        refreshShoppingListUseCase().fold(
+            // A failed observe flow has completed (its catch emitted once), so re-subscribe;
+            // the repository's StateFlow replays the freshly refreshed list immediately.
+            onSuccess = { observe() },
+            onFailure = { setState { copy(isLoading = false, loadError = true) } },
+        )
+    }
+
+    private suspend fun toggleDone(entryId: Int) {
+        val entry = currentState.groups.asSequence()
+            .flatMap { it.entries.asSequence() }
+            .firstOrNull { it.id == entryId }
+            ?: return
+        val newDone = !entry.done
+
+        // Optimistic: the cross-off animates immediately; the repository confirms with the
+        // same value, and a failure reverts the flip (the cache never changed).
+        setState { copy(groups = groups.withEntryDone(entryId, newDone)) }
+        setEntryDoneUseCase(SetEntryDoneUCRequest(entryId, newDone)).onFailure {
+            setState { copy(groups = groups.withEntryDone(entryId, entry.done)) }
+            launchEffect(Effect.ShowError("No se pudo actualizar la lista"))
+        }
+    }
+
+    private suspend fun openAddDialog() {
+        setState { copy(addDialog = AddDialogUi()) }
+        loadDialogProducts()
+    }
+
+    private suspend fun loadDialogProducts() {
+        setState { copy(addDialog = addDialog?.copy(products = OptionsUi())) }
+        val products = getProductsUseCase().toOptionsUi { it.toOption() }
+        setState {
+            // The dialog may have been dismissed while loading.
+            if (addDialog == null) this else copy(addDialog = addDialog.copy(products = products))
+        }
+    }
+
+    private suspend fun submitAdd() {
+        val dialog = currentState.addDialog ?: return
+        if (!dialog.isValid) return
+        val productName = dialog.selectedProductName ?: return
+
+        // Events are not serialized (each runs in its own coroutine), so a second OnAddSubmit
+        // dispatched before recomposition disables the button must be rejected here.
+        if (!submitLock.tryLock()) return
+        try {
+            setState { copy(addDialog = addDialog?.copy(isSubmitting = true)) }
+            addToShoppingListUseCase(
+                AddToShoppingListUCRequest(
+                    productId = dialog.selectedProductId!!,
+                    amount = dialog.amount.toDouble(),
+                )
+            ).fold(
+                onSuccess = {
+                    setState { copy(addDialog = null) }
+                    launchEffect(Effect.ProductAdded(productName))
+                },
+                onFailure = {
+                    setState { copy(addDialog = addDialog?.copy(isSubmitting = false)) }
+                    launchEffect(Effect.ShowError("No se pudo añadir el producto"))
+                },
+            )
+        } finally {
+            submitLock.unlock()
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
@@ -59,7 +59,6 @@ internal class ShoppingListViewModel(
         val products: OptionsUi = OptionsUi(),
         val selectedProductId: Int? = null,
         val amount: String = "1",
-        val isSubmitting: Boolean = false,
     ) {
         val amountValid: Boolean
             get() = amount.toDoubleOrNull()?.let { it > 0.0 } == true

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModel.kt
@@ -158,7 +158,9 @@ internal class ShoppingListViewModel(
         // dispatched before recomposition disables the button must be rejected here.
         if (!submitLock.tryLock()) return
         try {
-            setState { copy(addDialog = addDialog?.copy(isSubmitting = true)) }
+            // The dialog closes right away; the screen shows the loading skeleton until the
+            // repository's post-add refresh lands in the observed cache.
+            setState { copy(addDialog = null, isLoading = true) }
             addToShoppingListUseCase(
                 AddToShoppingListUCRequest(
                     productId = dialog.selectedProductId!!,
@@ -166,11 +168,13 @@ internal class ShoppingListViewModel(
                 )
             ).fold(
                 onSuccess = {
-                    setState { copy(addDialog = null) }
+                    // observe() normally cleared this already when the refreshed cache emitted;
+                    // this covers an emission deduped by the StateFlow.
+                    setState { copy(isLoading = false) }
                     launchEffect(Effect.ProductAdded(productName))
                 },
                 onFailure = {
-                    setState { copy(addDialog = addDialog?.copy(isSubmitting = false)) }
+                    setState { copy(isLoading = false) }
                     launchEffect(Effect.ShowError("No se pudo añadir el producto"))
                 },
             )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/GroupAccent.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/GroupAccent.kt
@@ -1,0 +1,49 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.component
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+/** Per-group accent roles for the shopping list "ticket" cards. */
+internal data class GroupAccent(
+    val label: Color,
+    val outline: Color,
+    val container: Color,
+)
+
+/**
+ * Deterministic, theme-aware accent derived from the group name: the name's hashCode picks
+ * one of 24 hue families (15° steps); saturation and lightness are fixed per theme and role,
+ * deliberately mid-chroma so the accent labels the group without fighting the colour scheme.
+ * Two groups may share a family — the colour is identity, not meaning.
+ *
+ * A null [groupName] (ungrouped products) gets a neutral accent from the colour scheme.
+ */
+@Composable
+internal fun groupAccent(groupName: String?): GroupAccent {
+    if (groupName == null) {
+        return GroupAccent(
+            label = MaterialTheme.colorScheme.onSurfaceVariant,
+            outline = MaterialTheme.colorScheme.outlineVariant,
+            container = MaterialTheme.colorScheme.surfaceContainerLow,
+        )
+    }
+    val hue = groupHue(groupName)
+    return if (isSystemInDarkTheme()) {
+        GroupAccent(
+            label = Color.hsl(hue, 0.45f, 0.78f),
+            outline = Color.hsl(hue, 0.25f, 0.40f),
+            container = Color.hsl(hue, 0.26f, 0.145f),
+        )
+    } else {
+        GroupAccent(
+            label = Color.hsl(hue, 0.48f, 0.33f),
+            outline = Color.hsl(hue, 0.35f, 0.68f),
+            container = Color.hsl(hue, 0.55f, 0.965f),
+        )
+    }
+}
+
+internal fun groupHue(name: String): Float =
+    (((name.trim().lowercase().hashCode() % 360) + 360) % 360) / 15 * 15f

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/GroupAccent.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/GroupAccent.kt
@@ -34,13 +34,13 @@ internal fun groupAccent(groupName: String?): GroupAccent {
         GroupAccent(
             label = Color.hsl(hue, 0.45f, 0.78f),
             outline = Color.hsl(hue, 0.25f, 0.40f),
-            container = Color.hsl(hue, 0.26f, 0.145f),
+            container = Color.hsl(hue, 0.30f, 0.17f),
         )
     } else {
         GroupAccent(
             label = Color.hsl(hue, 0.48f, 0.33f),
             outline = Color.hsl(hue, 0.35f, 0.68f),
-            container = Color.hsl(hue, 0.55f, 0.965f),
+            container = Color.hsl(hue, 0.55f, 0.93f),
         )
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/ShoppingGroupCard.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/component/ShoppingGroupCard.kt
@@ -1,0 +1,253 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.srfmolina.krocy.ui.presentation.common.HintCard
+import com.srfmolina.krocy.ui.presentation.common.skeleton.skeleton
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingGroupUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingListEntryUi
+import com.srfmolina.krocy.ui.presentation.theme.KrocyTheme
+import com.srfmolina.krocy.ui.presentation.theme.spacing
+
+/**
+ * A product group as a "ticket": the group name fixed to the left just above an outlined card,
+ * both tinted with the group's [groupAccent]. The card's top-left corner is deliberately tighter
+ * than the others so the label reads as anchored to its card. When every entry is crossed off,
+ * the counter morphs into a check and the card settles to neutral colours.
+ */
+@Composable
+internal fun ShoppingGroupCard(
+    group: ShoppingGroupUi,
+    onToggleDone: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = groupAccent(group.name)
+    val outlineColor by animateColorAsState(
+        targetValue = if (group.allDone) MaterialTheme.colorScheme.outlineVariant else accent.outline,
+        label = "groupOutline",
+    )
+    val containerColor by animateColorAsState(
+        targetValue = if (group.allDone) MaterialTheme.colorScheme.surfaceContainerLow else accent.container,
+        label = "groupContainer",
+    )
+
+    Column(modifier = modifier) {
+        GroupHeader(group = group, labelColor = accent.label)
+        OutlinedCard(
+            shape = RoundedCornerShape(
+                topStart = 6.dp,
+                topEnd = 18.dp,
+                bottomEnd = 18.dp,
+                bottomStart = 18.dp,
+            ),
+            colors = CardDefaults.outlinedCardColors(containerColor = containerColor),
+            border = BorderStroke(1.dp, outlineColor),
+        ) {
+            group.entries.forEachIndexed { index, entry ->
+                if (index > 0) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = MaterialTheme.spacing.s4),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                }
+                ShoppingEntryRow(entry = entry, onToggleDone = onToggleDone)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupHeader(
+    group: ShoppingGroupUi,
+    labelColor: Color,
+) {
+    // Finished groups stop shouting: the label fades while keeping its hue.
+    val labelAlpha by animateFloatAsState(
+        targetValue = if (group.allDone) 0.62f else 1f,
+        label = "groupLabelAlpha",
+    )
+    val skeletonId = group.entries.firstOrNull()?.id ?: 0
+
+    Row(
+        modifier = Modifier.padding(
+            start = MaterialTheme.spacing.s2,
+            end = MaterialTheme.spacing.s1,
+            bottom = MaterialTheme.spacing.s1,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
+    ) {
+        Text(
+            text = group.displayName,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = labelColor,
+            modifier = Modifier
+                .graphicsLayer { alpha = labelAlpha }
+                .skeleton(id = skeletonId),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s0),
+            modifier = Modifier.skeleton(id = skeletonId),
+        ) {
+            if (group.allDone) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = "Grupo completado",
+                    tint = labelColor,
+                    modifier = Modifier
+                        .size(14.dp)
+                        .graphicsLayer { alpha = labelAlpha },
+                )
+            }
+            Text(
+                text = "${group.doneCount}/${group.entries.size}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShoppingEntryRow(
+    entry: ShoppingListEntryUi,
+    onToggleDone: (Int) -> Unit,
+) {
+    // The strikethrough draws itself left→right; TextDecoration.LineThrough cannot animate.
+    val strikeProgress by animateFloatAsState(
+        targetValue = if (entry.done) 1f else 0f,
+        animationSpec = tween(durationMillis = 320, easing = CubicBezierEasing(0.3f, 0f, 0.1f, 1f)),
+        label = "strike",
+    )
+    val nameColor by animateColorAsState(
+        targetValue = MaterialTheme.colorScheme.onSurface.let {
+            if (entry.done) it.copy(alpha = 0.38f) else it
+        },
+        label = "entryName",
+    )
+    val hintColor by animateColorAsState(
+        targetValue = if (entry.done) {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        } else {
+            MaterialTheme.colorScheme.primaryContainer
+        },
+        label = "entryHint",
+    )
+    val strikeColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                onClickLabel = if (entry.done) "Desmarcar" else "Marcar como comprado",
+            ) { onToggleDone(entry.id) }
+            .padding(horizontal = MaterialTheme.spacing.s4, vertical = MaterialTheme.spacing.s3)
+            .semantics { stateDescription = if (entry.done) "Comprado" else "Pendiente" },
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2),
+    ) {
+        Text(
+            text = entry.name,
+            style = MaterialTheme.typography.headlineSmall,
+            color = nameColor,
+            modifier = Modifier
+                .skeleton(id = entry.id)
+                .drawWithContent {
+                    drawContent()
+                    if (strikeProgress > 0f) {
+                        val y = size.height * 0.55f
+                        drawLine(
+                            color = strikeColor,
+                            start = Offset(0f, y),
+                            end = Offset(size.width * strikeProgress, y),
+                            strokeWidth = 2.5.dp.toPx(),
+                            cap = StrokeCap.Round,
+                        )
+                    }
+                },
+        )
+        HintCard(
+            text = entry.quantity,
+            containerColor = hintColor,
+            modifier = Modifier.skeleton(id = entry.id),
+        )
+    }
+}
+
+// PREVIEW //
+
+private val previewGroups = listOf(
+    ShoppingGroupUi(
+        name = "Frutas y verduras",
+        entries = listOf(
+            ShoppingListEntryUi(1, "Manzanas", "4 uds", done = false),
+            ShoppingListEntryUi(2, "Plátanos", "1 racimo", done = true),
+            ShoppingListEntryUi(3, "Tomates", "6 uds", done = false),
+        ),
+    ),
+    ShoppingGroupUi(
+        name = "Lácteos",
+        entries = listOf(
+            ShoppingListEntryUi(4, "Leche entera", "3 briks", done = true),
+            ShoppingListEntryUi(5, "Yogur natural", "8 uds", done = true),
+        ),
+    ),
+    ShoppingGroupUi(
+        name = null,
+        entries = listOf(
+            ShoppingListEntryUi(6, "Pan de molde", "1 paquete", done = false),
+        ),
+    ),
+)
+
+@PreviewLightDark
+@Composable
+private fun ShoppingGroupCardPreview() {
+    KrocyTheme {
+        Surface {
+            Column(
+                modifier = Modifier.padding(MaterialTheme.spacing.s4),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s6),
+            ) {
+                previewGroups.forEach { group ->
+                    ShoppingGroupCard(group = group, onToggleDone = {})
+                }
+            }
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/mapper/ShoppingListUiMapper.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/mapper/ShoppingListUiMapper.kt
@@ -1,0 +1,34 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.mapper
+
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingGroupUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingListEntryUi
+import kotlin.math.floor
+
+internal fun List<ShoppingListEntry>.toUi(): List<ShoppingGroupUi> =
+    groupBy { it.groupName }
+        .map { (groupName, entries) ->
+            ShoppingGroupUi(name = groupName, entries = entries.map { it.toUi() })
+        }
+        // Alphabetical, with the ungrouped section always last.
+        .sortedWith(compareBy({ it.name == null }, { it.displayName.lowercase() }))
+
+internal fun ShoppingListEntry.toUi(): ShoppingListEntryUi = ShoppingListEntryUi(
+    id = id,
+    name = productName,
+    quantity = "${amount.toAmountText()} ${if (amount == 1.0) unitName else unitNamePlural}",
+    done = done,
+)
+
+/** Flips one entry's done flag, e.g. for an optimistic cross-off before the API confirms. */
+internal fun List<ShoppingGroupUi>.withEntryDone(entryId: Int, done: Boolean): List<ShoppingGroupUi> =
+    map { group ->
+        group.copy(
+            entries = group.entries.map { entry ->
+                if (entry.id == entryId) entry.copy(done = done) else entry
+            }
+        )
+    }
+
+private fun Double.toAmountText(): String =
+    if (this == floor(this)) toInt().toString() else toString()

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUi.kt
@@ -7,6 +7,9 @@ internal data class ShoppingGroupUi(
 ) {
     val displayName: String get() = name ?: UNGROUPED_DISPLAY_NAME
 
+    /** Stable lazy-list key. [displayName] cannot be the key: a real group named "Otros" would collide with the ungrouped section. */
+    val key: String get() = name ?: "\u0000ungrouped"
+
     val doneCount: Int get() = entries.count { it.done }
 
     val allDone: Boolean get() = entries.isNotEmpty() && doneCount == entries.size

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUi.kt
@@ -1,0 +1,17 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model
+
+/** A product group section of the shopping list. [name] is null for ungrouped products. */
+internal data class ShoppingGroupUi(
+    val name: String?,
+    val entries: List<ShoppingListEntryUi>,
+) {
+    val displayName: String get() = name ?: UNGROUPED_DISPLAY_NAME
+
+    val doneCount: Int get() = entries.count { it.done }
+
+    val allDone: Boolean get() = entries.isNotEmpty() && doneCount == entries.size
+
+    companion object {
+        const val UNGROUPED_DISPLAY_NAME = "Otros"
+    }
+}

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingListEntryUi.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingListEntryUi.kt
@@ -1,0 +1,8 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model
+
+internal data class ShoppingListEntryUi(
+    val id: Int,
+    val name: String,
+    val quantity: String,
+    val done: Boolean,
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/navigation/ShoppingListNavigation.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/navigation/ShoppingListNavigation.kt
@@ -1,0 +1,45 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ShoppingCart
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
+import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
+import com.srfmolina.krocy.ui.presentation.common.model.SnackbarConfigurationUi
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListScreen
+import com.srfmolina.krocy.ui.presentation.navigation.NavigationItemUi
+import com.srfmolina.krocy.ui.presentation.navigation.ShoppingListRoute
+import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
+
+internal fun NavController.navigateToShoppingList(
+    navOptions: NavOptions? = null
+) = navigate(route = ShoppingListRoute, navOptions)
+
+internal fun NavGraphBuilder.shoppingListScreen(
+    onChangeTopBar: (TopBarConfigurationUi) -> Unit,
+    onChangeFab: (FabConfigurationUi) -> Unit,
+    onChangeDialog: (DialogConfigurationUi?) -> Unit,
+    onOpenNavRail: () -> Unit,
+    onShowSnackbar: (SnackbarConfigurationUi) -> Unit
+) {
+    composable<ShoppingListRoute> {
+        ShoppingListScreen(
+            onChangeTopBar = onChangeTopBar,
+            onChangeFab = onChangeFab,
+            onChangeDialog = onChangeDialog,
+            onOpenNavRail = onOpenNavRail,
+            onShowSnackbar = onShowSnackbar
+        )
+    }
+}
+
+internal fun NavController.shoppingListNavigationItemUi() = NavigationItemUi(
+    icon = Icons.Outlined.ShoppingCart,
+    label = "Compra",
+    contentDescription = "Botón navegación Lista de la compra",
+    navigateTo = ::navigateToShoppingList,
+    route = ShoppingListRoute
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/AppNavGraph.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/AppNavGraph.kt
@@ -3,6 +3,7 @@ package com.srfmolina.krocy.ui.presentation.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.SnackbarConfigurationUi
 import com.srfmolina.krocy.ui.presentation.feature.creation.navigation.createProductScreen
@@ -10,6 +11,7 @@ import com.srfmolina.krocy.ui.presentation.feature.creation.navigation.navigateT
 import com.srfmolina.krocy.ui.presentation.feature.login.navigation.loginScreen
 import com.srfmolina.krocy.ui.presentation.feature.purchase.navigation.navigateToPurchase
 import com.srfmolina.krocy.ui.presentation.feature.purchase.navigation.purchaseScreen
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.navigation.shoppingListScreen
 import com.srfmolina.krocy.ui.presentation.feature.splash.navigation.splashScreen
 import com.srfmolina.krocy.ui.presentation.feature.stock.navigation.stockScreen
 import com.srfmolina.krocy.ui.presentation.feature.welcome.navigation.welcomeScreen
@@ -20,6 +22,7 @@ internal fun NavGraphBuilder.appNavGraph(
     navController: NavController,
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
     onChangeFab: (FabConfigurationUi) -> Unit,
+    onChangeDialog: (DialogConfigurationUi?) -> Unit,
     onOpenNavRail: () -> Unit,
     onShowSnackbar: (SnackbarConfigurationUi) -> Unit
 ){
@@ -42,6 +45,14 @@ internal fun NavGraphBuilder.appNavGraph(
             onOpenNavRail = onOpenNavRail,
             onNavigateToCreateProduct = { navController.navigateToCreateProduct() },
             onNavigateToPurchase = { navController.navigateToPurchase() },
+            onShowSnackbar = onShowSnackbar
+        )
+
+        shoppingListScreen(
+            onChangeTopBar = onChangeTopBar,
+            onChangeFab = onChangeFab,
+            onChangeDialog = onChangeDialog,
+            onOpenNavRail = onOpenNavRail,
             onShowSnackbar = onShowSnackbar
         )
 

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/NavigationComponent.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/NavigationComponent.kt
@@ -3,6 +3,7 @@ package com.srfmolina.krocy.ui.presentation.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.srfmolina.krocy.ui.presentation.common.model.DialogConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.FabConfigurationUi
 import com.srfmolina.krocy.ui.presentation.common.model.SnackbarConfigurationUi
 import com.srfmolina.krocy.ui.presentation.navigation.component.topbar.model.TopBarConfigurationUi
@@ -12,10 +13,11 @@ internal fun NavigationComponent(
     navController: NavHostController,
     onChangeTopBar: (TopBarConfigurationUi) -> Unit,
     onChangeFab: (FabConfigurationUi) -> Unit,
+    onChangeDialog: (DialogConfigurationUi?) -> Unit,
     onOpenNavRail: () -> Unit,
     onShowSnackbar: (SnackbarConfigurationUi) -> Unit
 ) {
     NavHost(navController = navController, startDestination = AppRoute) {
-        appNavGraph(navController, onChangeTopBar, onChangeFab, onOpenNavRail, onShowSnackbar)
+        appNavGraph(navController, onChangeTopBar, onChangeFab, onChangeDialog, onOpenNavRail, onShowSnackbar)
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/model/RailRouteRegistry.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/component/rail/model/RailRouteRegistry.kt
@@ -4,13 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.navigation.shoppingListNavigationItemUi
 import com.srfmolina.krocy.ui.presentation.feature.stock.navigation.stockNavigationItemUi
 import com.srfmolina.krocy.ui.presentation.navigation.KrocyRoute
 import com.srfmolina.krocy.ui.presentation.navigation.NavigationItemUi
+import com.srfmolina.krocy.ui.presentation.navigation.ShoppingListRoute
 import com.srfmolina.krocy.ui.presentation.navigation.StockRoute
 
 private val railRoutes: List<KrocyRoute> = listOf(
     StockRoute,
+    ShoppingListRoute,
     // Add new top-level destinations here
 )
 
@@ -23,5 +26,6 @@ internal fun NavController.currentRailRoute(): KrocyRoute? {
 
 internal fun NavHostController.appRailItems(): List<NavigationItemUi> = listOf(
     stockNavigationItemUi(),
+    shoppingListNavigationItemUi(),
     // Mirror railRoutes order here
 )

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/route.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/navigation/route.kt
@@ -17,6 +17,9 @@ data object LoginRoute: KrocyRoute
 data object StockRoute: KrocyRoute
 
 @Serializable
+data object ShoppingListRoute: KrocyRoute
+
+@Serializable
 data object CreateProductRoute: KrocyRoute
 
 @Serializable

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
@@ -223,7 +224,7 @@ class ShoppingListViewModelTest {
     }
 
     @Test
-    fun `submitting the add dialog adds the product and closes it`() = runTest {
+    fun `submitting dismisses the dialog immediately and shows loading until the add completes`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val repo = ShoppingListRepositoryFake(defaultEntries)
         val vm = viewModel(repo)
@@ -239,16 +240,21 @@ class ShoppingListViewModelTest {
         vm.launchEvent(Event.OnAddAmountChange("2"))
         advanceUntilIdle()
         vm.launchEvent(Event.OnAddSubmit)
+        runCurrent() // request still in flight: the fake's addProduct is parked at delay(100)
+
+        assertNull(vm.state.value.addDialog)
+        assertTrue(vm.state.value.isLoading)
+
         advanceUntilIdle()
 
         assertEquals(listOf(7 to 2.0), repo.added)
-        assertNull(vm.state.value.addDialog)
+        assertFalse(vm.state.value.isLoading)
         assertEquals("Queso curado", (effects.single() as Effect.ProductAdded).productName)
         collector.cancel()
     }
 
     @Test
-    fun `a failing add keeps the dialog open and surfaces an error`() = runTest {
+    fun `a failing add stops the loading, keeps the dialog closed and surfaces an error`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val repo = ShoppingListRepositoryFake(defaultEntries, failAdd = true)
         val vm = viewModel(repo)
@@ -265,8 +271,8 @@ class ShoppingListViewModelTest {
         vm.launchEvent(Event.OnAddSubmit)
         advanceUntilIdle()
 
-        val dialog = assertNotNull(vm.state.value.addDialog)
-        assertFalse(dialog.isSubmitting)
+        assertNull(vm.state.value.addDialog)
+        assertFalse(vm.state.value.isLoading)
         assertTrue(effects.single() is Effect.ShowError)
         collector.cancel()
     }

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
@@ -69,6 +69,10 @@ class ShoppingListViewModelTest {
             delay(100) // keep the request in flight so a second submit can race it
             if (failAdd) error("boom")
             added += productId to amount
+            // Mirror production: the repository's cache emits the newly added entry before
+            // addProduct returns, which is what actually ends the ViewModel's loading state.
+            entriesFlow.value = entriesFlow.value +
+                ShoppingListEntry(99, productId, "Queso curado", null, amount, "ud", "uds", done = false)
         }
 
         override suspend fun forceRefresh() {
@@ -250,6 +254,9 @@ class ShoppingListViewModelTest {
         assertEquals(listOf(7 to 2.0), repo.added)
         assertFalse(vm.state.value.isLoading)
         assertEquals("Queso curado", (effects.single() as Effect.ProductAdded).productName)
+        // The loading ended via the repository's cache emission delivering the new entry,
+        // not just the defensive fallback in the ViewModel's success branch.
+        assertEquals("Queso curado", vm.entry(99)?.name)
         collector.cancel()
     }
 

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
@@ -296,6 +296,8 @@ class ShoppingListViewModelTest {
         advanceUntilIdle()
         vm.launchEvent(Event.OnAddProductSelected(7))
         advanceUntilIdle()
+        // The guard is submitAdd's null check: the first submit nulls the dialog before
+        // any suspension point, so the second one returns early. No lock is involved.
         vm.launchEvent(Event.OnAddSubmit)
         vm.launchEvent(Event.OnAddSubmit)
         advanceUntilIdle()

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/ShoppingListViewModelTest.kt
@@ -1,0 +1,311 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist
+
+import com.srfmolina.krocy.domain.model.product.NewProduct
+import com.srfmolina.krocy.domain.model.product.NewQuConversion
+import com.srfmolina.krocy.domain.model.product.ProductOption
+import com.srfmolina.krocy.domain.model.product.ProductPurchaseInfo
+import com.srfmolina.krocy.domain.model.shoppinglist.ShoppingListEntry
+import com.srfmolina.krocy.domain.repository.ProductRepository
+import com.srfmolina.krocy.domain.repository.ShoppingListRepository
+import com.srfmolina.krocy.domain.usecase.product.GetProductsUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.AddToShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.ObserveShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.RefreshShoppingListUseCase
+import com.srfmolina.krocy.domain.usecase.shoppinglist.SetEntryDoneUseCase
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Effect
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.ShoppingListViewModel.Event
+import com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model.ShoppingListEntryUi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShoppingListViewModelTest {
+
+    private val defaultEntries = listOf(
+        ShoppingListEntry(10, 1, "Leche entera", "Lácteos", 3.0, "brik", "briks", done = false),
+        ShoppingListEntry(11, 2, "Manzanas", "Frutas y verduras", 4.0, "ud", "uds", done = false),
+        ShoppingListEntry(12, 3, "Pan de molde", null, 1.0, "paquete", "paquetes", done = false),
+    )
+
+    private class ShoppingListRepositoryFake(
+        entries: List<ShoppingListEntry>,
+        var failObserve: Boolean = false,
+        var failSetDone: Boolean = false,
+        var failAdd: Boolean = false,
+        var failRefresh: Boolean = false,
+    ) : ShoppingListRepository {
+        val entriesFlow = MutableStateFlow(entries)
+        val doneCalls = mutableListOf<Pair<Int, Boolean>>()
+        val added = mutableListOf<Pair<Int, Double>>()
+        var refreshCalls = 0
+
+        override fun getShoppingList(): Flow<List<ShoppingListEntry>> =
+            if (failObserve) flow { error("boom") } else entriesFlow
+
+        override suspend fun setDone(entryId: Int, done: Boolean) {
+            if (failSetDone) error("boom")
+            doneCalls += entryId to done
+        }
+
+        override suspend fun addProduct(productId: Int, amount: Double) {
+            delay(100) // keep the request in flight so a second submit can race it
+            if (failAdd) error("boom")
+            added += productId to amount
+        }
+
+        override suspend fun forceRefresh() {
+            refreshCalls++
+            if (failRefresh) error("boom")
+        }
+    }
+
+    private class ProductRepositoryStub(
+        var throwOnGetProducts: Boolean = false,
+    ) : ProductRepository {
+        override suspend fun createProduct(product: NewProduct): Int = 1
+        override suspend fun createQuConversion(conversion: NewQuConversion): Int = 1
+        override suspend fun getProducts(): List<ProductOption> {
+            if (throwOnGetProducts) error("boom")
+            return listOf(ProductOption(id = 7, name = "Queso curado"))
+        }
+        override suspend fun getProductPurchaseInfo(productId: Int): ProductPurchaseInfo =
+            error("unused")
+    }
+
+    private fun viewModel(
+        repo: ShoppingListRepository = ShoppingListRepositoryFake(defaultEntries),
+        productRepo: ProductRepository = ProductRepositoryStub(),
+    ) = ShoppingListViewModel(
+        observeShoppingListUseCase = ObserveShoppingListUseCase(repo),
+        refreshShoppingListUseCase = RefreshShoppingListUseCase(repo),
+        setEntryDoneUseCase = SetEntryDoneUseCase(repo),
+        addToShoppingListUseCase = AddToShoppingListUseCase(repo),
+        getProductsUseCase = GetProductsUseCase(productRepo),
+    )
+
+    private fun ShoppingListViewModel.entry(id: Int): ShoppingListEntryUi? =
+        state.value.groups.flatMap { it.entries }.firstOrNull { it.id == id }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `init groups entries alphabetically with the ungrouped section last`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel()
+
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.isLoading)
+        assertEquals(
+            listOf("Frutas y verduras", "Lácteos", "Otros"),
+            vm.state.value.groups.map { it.displayName },
+        )
+        // Plural unit for amounts above one, singular for exactly one.
+        assertEquals("3 briks", vm.entry(10)?.quantity)
+        assertEquals("1 paquete", vm.entry(12)?.quantity)
+    }
+
+    @Test
+    fun `toggling an entry flips it optimistically and persists the change`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnToggleDone(10))
+        advanceUntilIdle()
+
+        assertTrue(vm.entry(10)?.done == true)
+        assertEquals(listOf(10 to true), repo.doneCalls)
+    }
+
+    @Test
+    fun `a failing toggle reverts the flip and surfaces an error`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries, failSetDone = true)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        val effects = mutableListOf<Effect>()
+        val collector = launch { vm.effect.collect { effects.add(it) } }
+
+        vm.launchEvent(Event.OnToggleDone(10))
+        advanceUntilIdle()
+
+        assertTrue(vm.entry(10)?.done == false)
+        assertTrue(effects.single() is Effect.ShowError)
+        collector.cancel()
+    }
+
+    @Test
+    fun `a failing load surfaces the error state and refresh recovers from it`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries, failObserve = true)
+        val vm = viewModel(repo)
+
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+        assertTrue(vm.state.value.loadError)
+
+        repo.failObserve = false
+        vm.launchEvent(Event.OnRefresh)
+        advanceUntilIdle()
+
+        assertEquals(1, repo.refreshCalls)
+        assertFalse(vm.state.value.loadError)
+        assertEquals(3, vm.state.value.groups.size)
+    }
+
+    @Test
+    fun `a failing refresh keeps the error state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries, failRefresh = true)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnRefresh)
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.loadError)
+        assertFalse(vm.state.value.isLoading)
+    }
+
+    @Test
+    fun `opening the add dialog loads the product options`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel()
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+
+        val dialog = assertNotNull(vm.state.value.addDialog)
+        assertEquals("Queso curado", dialog.products.options.single().label)
+        assertFalse(dialog.isValid) // no product selected yet
+    }
+
+    @Test
+    fun `a failing products load marks the dialog options as errored`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(productRepo = ProductRepositoryStub(throwOnGetProducts = true))
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+
+        assertTrue(assertNotNull(vm.state.value.addDialog).products.isError)
+    }
+
+    @Test
+    fun `submitting the add dialog adds the product and closes it`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        val effects = mutableListOf<Effect>()
+        val collector = launch { vm.effect.collect { effects.add(it) } }
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddProductSelected(7))
+        vm.launchEvent(Event.OnAddAmountChange("2"))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddSubmit)
+        advanceUntilIdle()
+
+        assertEquals(listOf(7 to 2.0), repo.added)
+        assertNull(vm.state.value.addDialog)
+        assertEquals("Queso curado", (effects.single() as Effect.ProductAdded).productName)
+        collector.cancel()
+    }
+
+    @Test
+    fun `a failing add keeps the dialog open and surfaces an error`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries, failAdd = true)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        val effects = mutableListOf<Effect>()
+        val collector = launch { vm.effect.collect { effects.add(it) } }
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddProductSelected(7))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddSubmit)
+        advanceUntilIdle()
+
+        val dialog = assertNotNull(vm.state.value.addDialog)
+        assertFalse(dialog.isSubmitting)
+        assertTrue(effects.single() is Effect.ShowError)
+        collector.cancel()
+    }
+
+    @Test
+    fun `a second submit while one is in flight adds a single product`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddProductSelected(7))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddSubmit)
+        vm.launchEvent(Event.OnAddSubmit)
+        advanceUntilIdle()
+
+        assertEquals(1, repo.added.size)
+    }
+
+    @Test
+    fun `submitting an invalid dialog does nothing`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val repo = ShoppingListRepositoryFake(defaultEntries)
+        val vm = viewModel(repo)
+        vm.launchEvent(Event.Init)
+        advanceUntilIdle()
+
+        vm.launchEvent(Event.OnOpenAddDialog)
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddAmountChange("0"))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnAddSubmit)
+        advanceUntilIdle()
+
+        assertTrue(repo.added.isEmpty())
+        assertNotNull(vm.state.value.addDialog)
+    }
+}

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUiTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/shoppinglist/model/ShoppingGroupUiTest.kt
@@ -1,0 +1,16 @@
+package com.srfmolina.krocy.ui.presentation.feature.shoppinglist.model
+
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+
+class ShoppingGroupUiTest {
+
+    @Test
+    fun `a group named Otros and the ungrouped section have distinct lazy-list keys`() {
+        val named = ShoppingGroupUi(name = "Otros", entries = emptyList())
+        val ungrouped = ShoppingGroupUi(name = null, entries = emptyList())
+
+        // Both display as "Otros", but lazy-list keys must be unique or composition throws.
+        assertNotEquals(named.key, ungrouped.key)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Shopping List feature: a screen that shows a staggered-grid of "ticket" cards grouped by product group, backed by a new repository that reconciles the list against Grocy's min-stock deficits and supports manually adding products and checking items off.

## Why a custom reconciliation instead of Grocy's `add-missing-products`

Grocy's own `/stock/shoppinglist/add-missing-products` endpoint can't do the job: it never updates amounts, never removes rows that are no longer deficient, and stamps rows with the purchase unit while writing amounts in stock units (verified against the demo server). So `ShoppingListRepositoryImpl` reconciles the list itself from `/stock/volatile` on each load/refresh:

- auto rows are created/updated/deleted to match current deficits, always in stock units
- auto rows are tagged with a `krocy:auto` note; every untagged row (added by hand here or in any other grocy client) is left alone by the sync except that crossed-off rows are cleared as bought
- checking an item off (`setDone`) patches the in-memory cache instead of refetching, so the cross-off is instant

## Grocy spec deviations

The `shopping_list` generic-entity schema is missing `done` and `qu_id`, even though the server returns and accepts both — `done` is the only way to persist a crossed-off row. Documented and worked around (regeneration-proof) in `grocy-client/SPEC-DEVIATIONS.md` item 7, plus a related fix for the `ExposedEntityNoDelete` enum in item 5. Guarded by a deserialization regression test.

## UI

- `ShoppingListScreen` + `ShoppingListViewModel` (MVI, per project convention): grouped staggered-grid list, top-bar refresh action, FAB menu to open an "add product" dialog, optimistic toggle-done with revert on failure.
- Adding a product dismisses the dialog immediately and shows the loading skeleton until the refreshed entry lands in the observed cache, rather than blocking on the network call.
- Each product group gets a deterministic, theme-aware colour accent derived from the group name (`GroupAccent.kt`), so cards read as grouped without needing a legend.
- New shared `KrocyDialog` / `KrocyFabMenu` components and `DialogConfigurationUi`, reusable outside this screen.
- New route wired into `AppNavGraph` and the navigation rail.

## Tests

- `ShoppingListRepositoryImplTest`: reconciliation against deficits, manual-row handling, add/merge, done round-trip.
- `ShoppingListViewModelTest`: dialog lifecycle, optimistic toggle + revert, add-submit loading/dedup behaviour.
- `GenericEntityDeserializationTest`: regression guard for the `done`/`qu_id` spec workaround.

