### PR TITLE
QR Login

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
         val jvmCommonMain by creating {
             dependsOn(commonMain.get())
             dependencies {
-                implementation(project(":domain"))
                 implementation(libs.zxing.core)
             }
         }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -21,7 +21,22 @@ kotlin {
 
     jvm()
 
+    // ZXing is a plain Java library and cannot be declared in a KMP commonMain. Both targets
+    // here are JVM-based, so a shared jvmCommon source set holds the decoder once - and lets
+    // jvmTest exercise the real thing instead of a stub.
+    applyDefaultHierarchyTemplate()
+
     sourceSets {
+        val jvmCommonMain by creating {
+            dependsOn(commonMain.get())
+            dependencies {
+                implementation(project(":domain"))
+                implementation(libs.zxing.core)
+            }
+        }
+        androidMain.get().dependsOn(jvmCommonMain)
+        jvmMain.get().dependsOn(jvmCommonMain)
+
         commonMain.dependencies {
             implementation(project(":domain"))
             implementation(project(":grocy-client"))

--- a/data/src/androidMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.android.kt
+++ b/data/src/androidMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.android.kt
@@ -1,0 +1,3 @@
+package com.srfmolina.krocy.data.qr
+
+internal actual fun createQrDecoder(): QrDecoder = ZxingQrDecoder()

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/di/DataModule.kt
@@ -12,12 +12,16 @@ import com.srfmolina.krocy.data.db.dao.KrocyItemDao
 import com.srfmolina.krocy.data.network.HassSessionSource
 import com.srfmolina.krocy.data.network.KtorHassSessionSource
 import com.srfmolina.krocy.data.network.buildImageHttpClient
+import com.srfmolina.krocy.data.qr.QrDecoder
+import com.srfmolina.krocy.data.qr.createQrDecoder
 import com.srfmolina.krocy.data.repository.impl.KrocyItemRepositoryImpl
 import com.srfmolina.krocy.data.repository.impl.LoginRepositoryImpl
+import com.srfmolina.krocy.data.repository.impl.QrScannerRepositoryImpl
 import com.srfmolina.krocy.data.repository.impl.ServerConfigRepositoryImpl
 import com.srfmolina.krocy.data.session.SessionManagerImpl
 import com.srfmolina.krocy.domain.repository.KrocyItemRepository
 import com.srfmolina.krocy.domain.repository.LoginRepository
+import com.srfmolina.krocy.domain.repository.QrScannerRepository
 import com.srfmolina.krocy.domain.repository.ServerConfigRepository
 import com.srfmolina.krocy.domain.session.SessionManager
 import org.koin.core.qualifier.named
@@ -40,6 +44,11 @@ val dataModule = module {
     single<HassSessionSource> { KtorHassSessionSource() }
     single<LoginRepository> { LoginRepositoryImpl(get(), get()) }
     single<SessionManager> { SessionManagerImpl() }
+
+    // QR scanning lives in the root module, not the session module: the user scans while
+    // logged out, before any session exists.
+    single<QrDecoder> { createQrDecoder() }
+    single<QrScannerRepository> { QrScannerRepositoryImpl(get()) }
 
     // Authenticated client for Coil image loading (survives login/logout)
     single(named("imageHttpClient")) { buildImageHttpClient(get(), get()) }

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.kt
@@ -1,0 +1,13 @@
+package com.srfmolina.krocy.data.qr
+
+import com.srfmolina.krocy.domain.model.server.QrFrame
+
+/**
+ * Reads a QR code out of a grayscale frame. Both platforms use the same ZXing implementation;
+ * the expect/actual pair exists only because ZXing cannot be declared in commonMain.
+ */
+internal interface QrDecoder {
+    fun decode(frame: QrFrame): String?
+}
+
+internal expect fun createQrDecoder(): QrDecoder

--- a/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/QrScannerRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/srfmolina/krocy/data/repository/impl/QrScannerRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.srfmolina.krocy.data.repository.impl
+
+import com.srfmolina.krocy.data.qr.QrDecoder
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import com.srfmolina.krocy.domain.repository.QrScannerRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal class QrScannerRepositoryImpl(
+    private val decoder: QrDecoder,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
+) : QrScannerRepository {
+
+    override suspend fun decode(frame: QrFrame): String? =
+        withContext(dispatcher) { decoder.decode(frame) }
+}

--- a/data/src/jvmCommonMain/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoder.kt
+++ b/data/src/jvmCommonMain/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoder.kt
@@ -12,6 +12,12 @@ import com.srfmolina.krocy.domain.model.server.QrFrame
 internal class ZxingQrDecoder : QrDecoder {
 
     override fun decode(frame: QrFrame): String? {
+        // A frame whose buffer is shorter than its dimensions is unreadable, not malformed
+        // input: ZXing's PlanarYUVLuminanceSource does not check this and the binarizer would
+        // index past the end. Returning null keeps it in the "no QR in this frame" path
+        // instead of surfacing to the user as "not a Grocy QR".
+        if (frame.luminance.size < frame.width * frame.height) return null
+
         val source = PlanarYUVLuminanceSource(
             frame.luminance,
             frame.width,

--- a/data/src/jvmCommonMain/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoder.kt
+++ b/data/src/jvmCommonMain/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoder.kt
@@ -1,0 +1,36 @@
+package com.srfmolina.krocy.data.qr
+
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.ChecksumException
+import com.google.zxing.FormatException
+import com.google.zxing.NotFoundException
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.qrcode.QRCodeReader
+import com.srfmolina.krocy.domain.model.server.QrFrame
+
+internal class ZxingQrDecoder : QrDecoder {
+
+    override fun decode(frame: QrFrame): String? {
+        val source = PlanarYUVLuminanceSource(
+            frame.luminance,
+            frame.width,
+            frame.height,
+            0,
+            0,
+            frame.width,
+            frame.height,
+            false
+        )
+        // A fresh reader per call: QRCodeReader is not thread safe and construction is cheap.
+        return try {
+            QRCodeReader().decode(BinaryBitmap(HybridBinarizer(source))).text
+        } catch (_: NotFoundException) {
+            null // no QR in this frame - by far the common case while the user aims
+        } catch (_: ChecksumException) {
+            null // a QR too damaged or blurry to trust
+        } catch (_: FormatException) {
+            null // something QR-shaped that is not a valid QR
+        }
+    }
+}

--- a/data/src/jvmMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.jvm.kt
+++ b/data/src/jvmMain/kotlin/com/srfmolina/krocy/data/qr/QrDecoder.jvm.kt
@@ -1,0 +1,3 @@
+package com.srfmolina.krocy.data.qr
+
+internal actual fun createQrDecoder(): QrDecoder = ZxingQrDecoder()

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoderTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoderTest.kt
@@ -1,0 +1,47 @@
+package com.srfmolina.krocy.data.qr
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ZxingQrDecoderTest {
+
+    /** Renders [text] as a QR code and flattens it into the grayscale frame the decoder eats. */
+    private fun qrFrameOf(text: String, size: Int = 240): QrFrame {
+        val matrix = QRCodeWriter().encode(text, BarcodeFormat.QR_CODE, size, size)
+        val luminance = ByteArray(size * size)
+        for (y in 0 until size) {
+            for (x in 0 until size) {
+                luminance[y * size + x] = if (matrix[x, y]) 0 else 255.toByte()
+            }
+        }
+        return QrFrame(luminance = luminance, width = size, height = size)
+    }
+
+    @Test
+    fun `decodes a rendered grocy payload`() {
+        val payload = "http://10.10.10.11:8080/api|LwasdaXXXXXXXXXXXXXXX"
+        assertEquals(payload, ZxingQrDecoder().decode(qrFrameOf(payload)))
+    }
+
+    @Test
+    fun `decodes a long home assistant payload`() {
+        val payload =
+            "http://192.168.1.20:8123/api/hassio_ingress/abc123_igrocy-addon/api|vXNvFkey"
+        assertEquals(payload, ZxingQrDecoder().decode(qrFrameOf(payload)))
+    }
+
+    @Test
+    fun `a blank frame decodes to null`() {
+        val size = 240
+        val blank = QrFrame(
+            luminance = ByteArray(size * size) { 255.toByte() },
+            width = size,
+            height = size
+        )
+        assertNull(ZxingQrDecoder().decode(blank))
+    }
+}

--- a/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoderTest.kt
+++ b/data/src/jvmTest/kotlin/com/srfmolina/krocy/data/qr/ZxingQrDecoderTest.kt
@@ -44,4 +44,15 @@ class ZxingQrDecoderTest {
         )
         assertNull(ZxingQrDecoder().decode(blank))
     }
+
+    @Test
+    fun `a frame whose buffer is smaller than its dimensions decodes to null`() {
+        val size = 240
+        val truncated = QrFrame(
+            luminance = ByteArray(size * size - 1),
+            width = size,
+            height = size
+        )
+        assertNull(ZxingQrDecoder().decode(truncated))
+    }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
@@ -8,6 +8,10 @@ private const val INGRESS_MARKER = "/api/hassio_ingress/"
 private const val MAX_PAYLOAD_LENGTH = 2048
 private const val MAX_API_KEY_LENGTH = 512
 
+/** Nothing legitimate is longer; an overlong URL exists only to push the confirmation
+ *  card's buttons and warning off screen. */
+private const val MAX_URL_LENGTH = 256
+
 /**
  * Printable ASCII, no space. Excludes CR, LF, tab and every control character - the API key is
  * sent verbatim as the `GROCY-API-KEY` header, where a CR or LF is header injection - and
@@ -17,6 +21,9 @@ private val SAFE_TEXT = Regex("[!-~]+")
 
 /** The proxy id is interpolated into a request path; this charset is all a real one uses. */
 private val SAFE_PROXY_ID = Regex("[A-Za-z0-9_.-]+")
+
+/** Hostname, IPv6 literal or port characters only - the authority must be exactly what it looks like. */
+private val SAFE_AUTHORITY = Regex("[A-Za-z0-9._~\\-:\\[\\]]+")
 
 /**
  * What a Grocy QR code carries: `<apiBaseUrl>|<apiKey>`.
@@ -61,6 +68,7 @@ sealed interface GrocyQrCredentials {
             if (!SAFE_TEXT.matches(apiKey)) return null
 
             val rawUrl = parts[0].trim()
+            if (rawUrl.length > MAX_URL_LENGTH) return null
             if (!SAFE_TEXT.matches(rawUrl) || !hasHttpScheme(rawUrl)) return null
             // A query, fragment or backslash is a way to make the URL we finally request differ
             // from the one the user reads in the form.
@@ -80,6 +88,7 @@ sealed interface GrocyQrCredentials {
             // they recognize and connects them to one they do not. Reject an authority that is
             // only a port ("http://:8080/") too - there is no host to connect to.
             if (authority.isEmpty() || '@' in authority || authority.startsWith(":")) return null
+            if (!SAFE_AUTHORITY.matches(authority)) return null
 
             val path = authorityAndPath.removePrefix(authority)
             if (path.contains("//")) return null

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
@@ -1,0 +1,96 @@
+package com.srfmolina.krocy.domain.model.server
+
+private const val PAYLOAD_SEPARATOR = "|"
+private const val API_SUFFIX = "/api"
+private const val INGRESS_MARKER = "/api/hassio_ingress/"
+
+/** A QR carries kilobytes; nothing legitimate here is long. */
+private const val MAX_PAYLOAD_LENGTH = 2048
+private const val MAX_API_KEY_LENGTH = 512
+
+/**
+ * Printable ASCII, no space. Excludes CR, LF, tab and every control character - the API key is
+ * sent verbatim as the `GROCY-API-KEY` header, where a CR or LF is header injection - and
+ * excludes non-ASCII, which in a host name means a homograph rather than a real server.
+ */
+private val SAFE_TEXT = Regex("[!-~]+")
+
+/** The proxy id is interpolated into a request path; this charset is all a real one uses. */
+private val SAFE_PROXY_ID = Regex("[A-Za-z0-9_.-]+")
+
+/**
+ * What a Grocy QR code carries: `<apiBaseUrl>|<apiKey>`.
+ *
+ * The Home Assistant variant is missing [ServerConfig.HomeAssistant.longLivedToken] on purpose -
+ * that token is minted in Home Assistant and can never appear in a Grocy QR, so the user still
+ * types it. This type is therefore *not* a ServerConfig; it is only what the QR knew.
+ *
+ * ## Trust
+ *
+ * A scanned payload is **untrusted input from an attacker-controllable source** - a sticker, a
+ * printed sheet, an image on a web page. Unlike a typed URL, the user did not choose this host.
+ * Every field is therefore validated here, at the boundary, rather than anywhere downstream:
+ * the parser is the only place that decides a QR is acceptable.
+ */
+sealed interface GrocyQrCredentials {
+
+    val apiKey: String
+
+    data class SelfHosted(
+        val serverUrl: String,
+        override val apiKey: String
+    ) : GrocyQrCredentials
+
+    data class HomeAssistant(
+        val haServerUrl: String,
+        val ingressProxyId: String,
+        override val apiKey: String
+    ) : GrocyQrCredentials
+
+    companion object {
+
+        /** Returns null for anything that is not a well-formed, safe Grocy QR payload. */
+        fun parse(raw: String): GrocyQrCredentials? {
+            if (raw.length > MAX_PAYLOAD_LENGTH) return null
+
+            val parts = raw.trim().split(PAYLOAD_SEPARATOR)
+            if (parts.size != 2) return null
+
+            val apiKey = parts[1].trim()
+            if (apiKey.isEmpty() || apiKey.length > MAX_API_KEY_LENGTH) return null
+            if (!SAFE_TEXT.matches(apiKey)) return null
+
+            val rawUrl = parts[0].trim()
+            if (!SAFE_TEXT.matches(rawUrl) || !hasHttpScheme(rawUrl)) return null
+            // A query, fragment or backslash is a way to make the URL we finally request differ
+            // from the one the user reads in the form.
+            if (rawUrl.any { it == '?' || it == '#' || it == '\\' }) return null
+
+            // The trailing "/api" is Grocy's REST root; every consumer wants the server root.
+            // A payload without it is still accepted - the suffix carries nothing we need.
+            var url = normalizeUrlScheme(rawUrl).trimEnd('/')
+            if (url.endsWith(API_SUFFIX)) url = url.removeSuffix(API_SUFFIX)
+            // Re-check after stripping: "http:///api" collapses to a bare scheme, which would
+            // otherwise sail through the authority check below as the host "http:".
+            if (!hasHttpScheme(url)) return null
+
+            val authorityAndPath = url.substringAfter("://")
+            val authority = authorityAndPath.substringBefore('/')
+            // Reject userinfo: "http://grocy.midominio.com@evil.host/" shows the user a host
+            // they recognize and connects them to one they do not.
+            if (authority.isEmpty() || '@' in authority) return null
+
+            val path = authorityAndPath.removePrefix(authority)
+            if (path.contains("//")) return null
+            if (path.split('/').any { it == "." || it == ".." }) return null
+
+            val markerIndex = url.indexOf(INGRESS_MARKER)
+            if (markerIndex < 0) return SelfHosted(serverUrl = url, apiKey = apiKey)
+
+            val haServerUrl = url.substring(0, markerIndex)
+            val proxyId = url.substring(markerIndex + INGRESS_MARKER.length)
+            if (haServerUrl.isEmpty() || !SAFE_PROXY_ID.matches(proxyId)) return null
+            return HomeAssistant(haServerUrl, proxyId, apiKey)
+        }
+    }
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentials.kt
@@ -70,15 +70,16 @@ sealed interface GrocyQrCredentials {
             // A payload without it is still accepted - the suffix carries nothing we need.
             var url = normalizeUrlScheme(rawUrl).trimEnd('/')
             if (url.endsWith(API_SUFFIX)) url = url.removeSuffix(API_SUFFIX)
-            // Re-check after stripping: "http:///api" collapses to a bare scheme, which would
-            // otherwise sail through the authority check below as the host "http:".
+            // Re-check after stripping: the suffix strip can reduce the URL to something that
+            // no longer carries a scheme at all.
             if (!hasHttpScheme(url)) return null
 
             val authorityAndPath = url.substringAfter("://")
             val authority = authorityAndPath.substringBefore('/')
             // Reject userinfo: "http://grocy.midominio.com@evil.host/" shows the user a host
-            // they recognize and connects them to one they do not.
-            if (authority.isEmpty() || '@' in authority) return null
+            // they recognize and connects them to one they do not. Reject an authority that is
+            // only a port ("http://:8080/") too - there is no host to connect to.
+            if (authority.isEmpty() || '@' in authority || authority.startsWith(":")) return null
 
             val path = authorityAndPath.removePrefix(authority)
             if (path.contains("//")) return null

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/QrFrame.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/QrFrame.kt
@@ -1,0 +1,17 @@
+package com.srfmolina.krocy.domain.model.server
+
+/**
+ * One grayscale camera frame on its way to the QR decoder: [luminance] holds `width * height`
+ * bytes, one per pixel, row-major.
+ *
+ * Deliberately not a data class - a ByteArray in a generated equals/hashCode compares by
+ * identity, which is a trap. Frames are transient carriers: never stored, never compared.
+ *
+ * No rotation field: QR finder patterns are rotation-invariant, so ZXing reads a sideways
+ * frame without help.
+ */
+class QrFrame(
+    val luminance: ByteArray,
+    val width: Int,
+    val height: Int
+)

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/QrScanOutcome.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/QrScanOutcome.kt
@@ -1,0 +1,14 @@
+package com.srfmolina.krocy.domain.model.server
+
+/**
+ * The result of examining a single camera frame.
+ *
+ * [NotFound] and [NotGrocy] must stay distinct: most frames simply contain no QR and have to be
+ * ignored in silence, while a QR that is not a Grocy payload has to raise an error - otherwise
+ * the user points the camera at the wrong code and watches nothing happen forever.
+ */
+sealed interface QrScanOutcome {
+    data object NotFound : QrScanOutcome
+    data object NotGrocy : QrScanOutcome
+    data class Found(val credentials: GrocyQrCredentials) : QrScanOutcome
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
@@ -33,13 +33,23 @@ fun isCleartextRisk(url: String): Boolean {
 }
 
 private fun isPrivateOrLocalHost(host: String): Boolean {
-    if (host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1") return true
+    if (host == "localhost" || host == "::1" || host == "[::1]") return true
     if (host.endsWith(".local") || host.endsWith(".lan") || host.endsWith(".home.arpa")) return true
-    if (host.startsWith("10.") || host.startsWith("192.168.")) return true
+
+    // Only a genuine dotted-quad IPv4 literal can be a private address. Checking string
+    // prefixes instead would read "10.attacker.com" as a LAN host and silently drop the
+    // cleartext warning for a public server.
     val octets = host.split('.')
-    if (octets.size == 4 && octets[0] == "172") {
-        val second = octets[1].toIntOrNull()
-        if (second != null && second in 16..31) return true // 172.16.0.0/12
+    if (octets.size != 4) return false
+    val numbers = octets.map { octet -> octet.toIntOrNull() ?: return false }
+    if (numbers.any { it !in 0..255 }) return false
+
+    return when {
+        numbers[0] == 127 -> true                          // loopback
+        numbers[0] == 10 -> true                           // 10.0.0.0/8
+        numbers[0] == 192 && numbers[1] == 168 -> true     // 192.168.0.0/16
+        numbers[0] == 172 && numbers[1] in 16..31 -> true  // 172.16.0.0/12
+        numbers[0] == 169 && numbers[1] == 254 -> true     // link-local
+        else -> false
     }
-    return false
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
@@ -28,13 +28,28 @@ fun normalizeUrlScheme(url: String): String = when {
  */
 fun isCleartextRisk(url: String): Boolean {
     if (!url.startsWith("http://", ignoreCase = true)) return false
-    val host = url.substringAfter("://").substringBefore('/').substringBefore(':').lowercase()
-    return !isPrivateOrLocalHost(host)
+    val authority = url.substringAfter("://").substringBefore('/')
+    return !isPrivateOrLocalHost(hostOf(authority).lowercase())
+}
+
+/**
+ * Drops the port from an authority. An IPv6 literal carries colons inside its brackets, so its
+ * port is whatever follows the closing bracket - cutting at the first colon would leave a bare
+ * "[" and read every IPv6 host, loopback included, as a public one.
+ */
+private fun hostOf(authority: String): String {
+    if (!authority.startsWith("[")) return authority.substringBefore(':')
+    val close = authority.indexOf(']')
+    // An unclosed bracket is not a literal we can vouch for; leave it to be flagged.
+    return if (close == -1) authority else authority.substring(0, close + 1)
 }
 
 private fun isPrivateOrLocalHost(host: String): Boolean {
-    if (host == "localhost" || host == "::1" || host == "[::1]") return true
+    if (host == "localhost" || host == "::1") return true
     if (host.endsWith(".local") || host.endsWith(".lan") || host.endsWith(".home.arpa")) return true
+    if (host.startsWith("[") && host.endsWith("]")) {
+        return isPrivateIpv6(host.substring(1, host.length - 1))
+    }
 
     // Only a genuine dotted-quad IPv4 literal can be a private address. Checking string
     // prefixes instead would read "10.attacker.com" as a LAN host and silently drop the
@@ -52,4 +67,17 @@ private fun isPrivateOrLocalHost(host: String): Boolean {
         numbers[0] == 169 && numbers[1] == 254 -> true     // link-local
         else -> false
     }
+}
+
+/**
+ * The IPv6 counterpart of the private IPv4 blocks above: loopback, unique local (fc00::/7) and
+ * link local (fe80::/10) are the ranges that can only mean the user's own network. Anything we
+ * cannot parse as one of those is treated as public, so a malformed literal warns rather than
+ * silently dropping the warning.
+ */
+private fun isPrivateIpv6(address: String): Boolean {
+    val bare = address.substringBefore('%') // a link-local address may carry a zone id
+    if (bare == "::1") return true
+    val firstGroup = bare.substringBefore(':').toIntOrNull(16) ?: return false
+    return firstGroup in 0xfc00..0xfdff || firstGroup in 0xfe80..0xfebf
 }

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalization.kt
@@ -1,0 +1,45 @@
+package com.srfmolina.krocy.domain.model.server
+
+/**
+ * URI schemes are case-insensitive (RFC 3986), so "HTTPS://" is as valid as "https://" -
+ * pasted URLs and mobile autocapitalization both produce mixed-case schemes.
+ */
+fun hasHttpScheme(url: String): Boolean =
+    url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
+
+/**
+ * Lowercases the scheme and nothing else: host and path may be legitimately case-sensitive,
+ * and the normalized form is what gets persisted and compared.
+ */
+fun normalizeUrlScheme(url: String): String = when {
+    url.startsWith("https://", ignoreCase = true) -> "https://" + url.substring("https://".length)
+    url.startsWith("http://", ignoreCase = true) -> "http://" + url.substring("http://".length)
+    else -> url
+}
+
+/**
+ * True when [url] would send credentials in the clear across a network that is not the user's
+ * own. Plain http on the LAN is a core Krocy use case (bare Grocy boxes, the Home Assistant
+ * add-on on `homeassistant.local`) and is not flagged; plain http to a public host means the
+ * API key and any Home Assistant token cross the internet readable by anyone on the path.
+ *
+ * This is the rule Android's network security config cannot express, which is why the app
+ * permits cleartext globally and the judgement is made here instead.
+ */
+fun isCleartextRisk(url: String): Boolean {
+    if (!url.startsWith("http://", ignoreCase = true)) return false
+    val host = url.substringAfter("://").substringBefore('/').substringBefore(':').lowercase()
+    return !isPrivateOrLocalHost(host)
+}
+
+private fun isPrivateOrLocalHost(host: String): Boolean {
+    if (host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1") return true
+    if (host.endsWith(".local") || host.endsWith(".lan") || host.endsWith(".home.arpa")) return true
+    if (host.startsWith("10.") || host.startsWith("192.168.")) return true
+    val octets = host.split('.')
+    if (octets.size == 4 && octets[0] == "172") {
+        val second = octets[1].toIntOrNull()
+        if (second != null && second in 16..31) return true // 172.16.0.0/12
+    }
+    return false
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/QrScannerRepository.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/repository/QrScannerRepository.kt
@@ -1,0 +1,9 @@
+package com.srfmolina.krocy.domain.repository
+
+import com.srfmolina.krocy.domain.model.server.QrFrame
+
+/** Reads QR codes out of raw camera frames. */
+interface QrScannerRepository {
+    /** The decoded text, or null when the frame holds no readable QR code. */
+    suspend fun decode(frame: QrFrame): String?
+}

--- a/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/login/ScanGrocyQrUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/srfmolina/krocy/domain/usecase/login/ScanGrocyQrUseCase.kt
@@ -1,0 +1,17 @@
+package com.srfmolina.krocy.domain.usecase.login
+
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import com.srfmolina.krocy.domain.model.server.QrScanOutcome
+import com.srfmolina.krocy.domain.repository.QrScannerRepository
+import com.srfmolina.krocy.domain.usecase.base.ResultUseCase
+
+class ScanGrocyQrUseCase(
+    private val qrScannerRepository: QrScannerRepository
+) : ResultUseCase<QrFrame, QrScanOutcome>() {
+    override suspend fun execute(params: QrFrame): QrScanOutcome {
+        val decoded = qrScannerRepository.decode(params) ?: return QrScanOutcome.NotFound
+        val credentials = GrocyQrCredentials.parse(decoded) ?: return QrScanOutcome.NotGrocy
+        return QrScanOutcome.Found(credentials)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
@@ -156,4 +156,22 @@ class GrocyQrCredentialsTest {
     fun `rejects an oversized api key inside a short payload`() {
         assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|" + "k".repeat(513)))
     }
+
+    @Test
+    fun `rejects an oversized url`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/" + "a".repeat(300) + "/api|key"))
+    }
+
+    @Test
+    fun `rejects a percent encoded userinfo separator in the authority`() {
+        assertNull(GrocyQrCredentials.parse("http://grocy.midominio.com%40evil.host/api|k"))
+    }
+
+    @Test
+    fun `accepts an ipv6 literal authority`() {
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("http://[::1]:8080", "key"),
+            GrocyQrCredentials.parse("http://[::1]:8080/api|key")
+        )
+    }
 }

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
@@ -1,0 +1,154 @@
+package com.srfmolina.krocy.domain.model.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GrocyQrCredentialsTest {
+
+    @Test
+    fun `parses a self hosted payload`() {
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("http://10.10.10.11:8080", "LwasdaXXXXXXXXXXXXXXX"),
+            GrocyQrCredentials.parse("http://10.10.10.11:8080/api|LwasdaXXXXXXXXXXXXXXX")
+        )
+    }
+
+    @Test
+    fun `parses a home assistant ingress payload`() {
+        val raw = "http://192.168.1.20:8123/api/hassio_ingress/abc123_igrocy-addon/api|vXNvFkey"
+        assertEquals(
+            GrocyQrCredentials.HomeAssistant(
+                haServerUrl = "http://192.168.1.20:8123",
+                ingressProxyId = "abc123_igrocy-addon",
+                apiKey = "vXNvFkey"
+            ),
+            GrocyQrCredentials.parse(raw)
+        )
+    }
+
+    @Test
+    fun `accepts an uppercase scheme and lowercases only the scheme`() {
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("https://Grocy.Example.com", "key"),
+            GrocyQrCredentials.parse("HTTPS://Grocy.Example.com/api|key")
+        )
+    }
+
+    @Test
+    fun `accepts a payload without the api suffix`() {
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("https://grocy.casa", "key"),
+            GrocyQrCredentials.parse("https://grocy.casa|key")
+        )
+    }
+
+    @Test
+    fun `trims surrounding whitespace and trailing slashes`() {
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("https://grocy.casa", "key"),
+            GrocyQrCredentials.parse("  https://grocy.casa/api/  |  key  ")
+        )
+    }
+
+    @Test
+    fun `rejects a payload without a separator`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api"))
+    }
+
+    @Test
+    fun `rejects a payload with two separators`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|key|extra"))
+    }
+
+    @Test
+    fun `rejects a blank api key`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|   "))
+    }
+
+    @Test
+    fun `rejects a non http payload`() {
+        assertNull(GrocyQrCredentials.parse("grocy.casa/api|key"))
+    }
+
+    @Test
+    fun `rejects a scheme with no host`() {
+        assertNull(GrocyQrCredentials.parse("http:///api|key"))
+    }
+
+    @Test
+    fun `rejects an ingress payload with an empty proxy id`() {
+        assertNull(GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress//api|key"))
+    }
+
+    @Test
+    fun `rejects an ingress payload whose proxy id carries extra path segments`() {
+        assertNull(
+            GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress/proxy/extra/api|key")
+        )
+    }
+
+    @Test
+    fun `rejects an arbitrary non grocy qr`() {
+        assertNull(GrocyQrCredentials.parse("WIFI:S:MiRed;T:WPA;P:secreto;;"))
+    }
+
+    // --- Untrusted-input hardening. A QR is attacker-controllable: a sticker, a printed
+    // sheet, an image on a page. Each case below is a way to make the request we finally
+    // send differ from what the user believes they scanned. ---
+
+    @Test
+    fun `rejects an api key carrying a header injection`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|key\r\nX-Evil: 1"))
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|key\nX-Evil: 1"))
+    }
+
+    @Test
+    fun `rejects a url carrying a control character`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa\u0000/api|key"))
+    }
+
+    @Test
+    fun `rejects userinfo that hides the real host`() {
+        assertNull(GrocyQrCredentials.parse("http://grocy.midominio.com@evil.host/api|key"))
+    }
+
+    @Test
+    fun `rejects a url with a query or a fragment`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api?next=evil|key"))
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api#evil|key"))
+    }
+
+    @Test
+    fun `rejects a url with a backslash`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa\\@evil.host/api|key"))
+    }
+
+    @Test
+    fun `rejects dot segments in the path`() {
+        assertNull(
+            GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress/../evil/api|key")
+        )
+    }
+
+    @Test
+    fun `rejects a proxy id that could steer the request path`() {
+        assertNull(GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress/a%2fb/api|k"))
+        assertNull(GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress/a b/api|k"))
+    }
+
+    @Test
+    fun `rejects a non ascii homograph host`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.c\u0430sa/api|key")) // Cyrillic a
+    }
+
+    @Test
+    fun `rejects an oversized payload`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|" + "k".repeat(4096)))
+    }
+
+    @Test
+    fun `rejects an oversized api key inside a short payload`() {
+        assertNull(GrocyQrCredentials.parse("https://grocy.casa/api|" + "k".repeat(513)))
+    }
+}

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/GrocyQrCredentialsTest.kt
@@ -77,6 +77,11 @@ class GrocyQrCredentialsTest {
     }
 
     @Test
+    fun `rejects an authority that is only a port`() {
+        assertNull(GrocyQrCredentials.parse("http://:8080/api|key"))
+    }
+
+    @Test
     fun `rejects an ingress payload with an empty proxy id`() {
         assertNull(GrocyQrCredentials.parse("http://ha.local:8123/api/hassio_ingress//api|key"))
     }

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
@@ -1,0 +1,31 @@
+package com.srfmolina.krocy.domain.model.server
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UrlNormalizationTest {
+
+    @Test
+    fun `https is never a cleartext risk`() {
+        assertFalse(isCleartextRisk("https://grocy.midominio.com"))
+    }
+
+    @Test
+    fun `plain http on the lan is not flagged`() {
+        assertFalse(isCleartextRisk("http://192.168.1.20:8123"))
+        assertFalse(isCleartextRisk("http://10.10.10.11:8080"))
+        assertFalse(isCleartextRisk("http://172.16.0.5"))
+        assertFalse(isCleartextRisk("http://172.31.255.1"))
+        assertFalse(isCleartextRisk("http://homeassistant.local:8123"))
+        assertFalse(isCleartextRisk("http://localhost:8080"))
+    }
+
+    @Test
+    fun `plain http to a public host is flagged`() {
+        assertTrue(isCleartextRisk("http://grocy.midominio.com"))
+        assertTrue(isCleartextRisk("http://203.0.113.10:8080"))
+        assertTrue(isCleartextRisk("http://172.32.0.1")) // just outside 172.16.0.0/12
+        assertTrue(isCleartextRisk("http://100.10.10.11")) // not the 10.0.0.0/8 block
+    }
+}

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
@@ -28,4 +28,23 @@ class UrlNormalizationTest {
         assertTrue(isCleartextRisk("http://172.32.0.1")) // just outside 172.16.0.0/12
         assertTrue(isCleartextRisk("http://100.10.10.11")) // not the 10.0.0.0/8 block
     }
+
+    @Test
+    fun `a public host that merely looks private is flagged`() {
+        assertTrue(isCleartextRisk("http://10.attacker.com"))
+        assertTrue(isCleartextRisk("http://192.168.attacker.com"))
+        assertTrue(isCleartextRisk("http://172.16.evil.com"))
+    }
+
+    @Test
+    fun `a malformed ipv4 literal is not treated as private`() {
+        assertTrue(isCleartextRisk("http://999.1.1.1"))
+        assertTrue(isCleartextRisk("http://10.0.0"))
+    }
+
+    @Test
+    fun `loopback and link local are not flagged`() {
+        assertFalse(isCleartextRisk("http://127.0.0.1:8080"))
+        assertFalse(isCleartextRisk("http://169.254.10.1"))
+    }
 }

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/model/server/UrlNormalizationTest.kt
@@ -47,4 +47,25 @@ class UrlNormalizationTest {
         assertFalse(isCleartextRisk("http://127.0.0.1:8080"))
         assertFalse(isCleartextRisk("http://169.254.10.1"))
     }
+
+    @Test
+    fun `an ipv6 literal on the user's own network is not flagged`() {
+        assertFalse(isCleartextRisk("http://[::1]"))
+        assertFalse(isCleartextRisk("http://[::1]:8080"))
+        assertFalse(isCleartextRisk("http://[fd12:3456:789a::1]:8123")) // unique local
+        assertFalse(isCleartextRisk("http://[fe80::1]")) // link local
+        assertFalse(isCleartextRisk("http://[fe80::1%eth0]:8080")) // zone id
+    }
+
+    @Test
+    fun `a public ipv6 literal is flagged`() {
+        assertTrue(isCleartextRisk("http://[2001:db8::1]:8080"))
+        assertTrue(isCleartextRisk("http://[fec0::1]")) // site local is not a private block
+    }
+
+    @Test
+    fun `a malformed ipv6 literal is not treated as private`() {
+        assertTrue(isCleartextRisk("http://[::1"))
+        assertTrue(isCleartextRisk("http://[]"))
+    }
 }

--- a/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/usecase/login/ScanGrocyQrUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/srfmolina/krocy/domain/usecase/login/ScanGrocyQrUseCaseTest.kt
@@ -1,0 +1,55 @@
+package com.srfmolina.krocy.domain.usecase.login
+
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import com.srfmolina.krocy.domain.model.server.QrScanOutcome
+import com.srfmolina.krocy.domain.repository.QrScannerRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ScanGrocyQrUseCaseTest {
+
+    private class QrScannerRepositoryFake(
+        private val onDecode: (QrFrame) -> String?
+    ) : QrScannerRepository {
+        override suspend fun decode(frame: QrFrame): String? = onDecode(frame)
+    }
+
+    private val frame = QrFrame(luminance = ByteArray(4), width = 2, height = 2)
+
+    @Test
+    fun `an empty frame is reported as not found`() = runTest {
+        val useCase = ScanGrocyQrUseCase(QrScannerRepositoryFake { null })
+        assertEquals(QrScanOutcome.NotFound, useCase(frame).getOrThrow())
+    }
+
+    @Test
+    fun `a non grocy qr is reported as not grocy`() = runTest {
+        val useCase = ScanGrocyQrUseCase(QrScannerRepositoryFake { "WIFI:S:MiRed;;" })
+        assertEquals(QrScanOutcome.NotGrocy, useCase(frame).getOrThrow())
+    }
+
+    @Test
+    fun `a grocy qr is reported as found with parsed credentials`() = runTest {
+        val useCase = ScanGrocyQrUseCase(
+            QrScannerRepositoryFake { "https://grocy.casa/api|key123" }
+        )
+        val outcome = useCase(frame).getOrThrow()
+        assertIs<QrScanOutcome.Found>(outcome)
+        assertEquals(
+            GrocyQrCredentials.SelfHosted("https://grocy.casa", "key123"),
+            outcome.credentials
+        )
+    }
+
+    @Test
+    fun `a decoder failure surfaces as a failed result`() = runTest {
+        val useCase = ScanGrocyQrUseCase(
+            QrScannerRepositoryFake { throw IllegalStateException("camera closed") }
+        )
+        assertTrue(useCase(frame).isFailure)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,10 @@ ktorfit = "2.7.2"
 adaptive = "1.2.0"
 coil = "3.2.0"
 datastore = "1.1.7"
+zxing = "3.5.3"
 
 [libraries]
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,8 +32,13 @@ adaptive = "1.2.0"
 coil = "3.2.0"
 datastore = "1.1.7"
 zxing = "3.5.3"
+camerax = "1.6.2"
 
 [libraries]
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-compose = { module = "androidx.camera:camera-compose", version.ref = "camerax" }
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -59,6 +59,10 @@ kotlin {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.koin.android)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.androidx.camera.core)
+            implementation(libs.androidx.camera.camera2)
+            implementation(libs.androidx.camera.lifecycle)
+            implementation(libs.androidx.camera.compose)
         }
 
         jvmMain.dependencies {

--- a/ui/src/androidHostTest/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/PackLuminanceTest.kt
+++ b/ui/src/androidHostTest/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/PackLuminanceTest.kt
@@ -1,0 +1,73 @@
+package com.srfmolina.krocy.ui.presentation.common.scanner
+
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class PackLuminanceTest {
+
+    @Test
+    fun `rowStride equal to width round-trips the bytes unchanged`() {
+        val width = 4
+        val height = 3
+        val bytes = ByteArray(width * height) { (it + 1).toByte() }
+        val buffer = ByteBuffer.wrap(bytes)
+
+        val result = packLuminance(buffer, rowStride = width, width = width, height = height)
+
+        assertContentEquals(bytes, result)
+    }
+
+    @Test
+    fun `rowStride greater than width drops exactly the padding`() {
+        val width = 4
+        val height = 3
+        val rowStride = 6
+        // Distinctive per-row values: row y has image bytes (y*10 + 1..width) then padding bytes.
+        val source = ByteArray(rowStride * height)
+        for (y in 0 until height) {
+            for (x in 0 until rowStride) {
+                source[y * rowStride + x] = if (x < width) {
+                    (y * 10 + x + 1).toByte()
+                } else {
+                    // Padding: a value that would be visibly wrong if it leaked into the output.
+                    (0x7F).toByte()
+                }
+            }
+        }
+        val buffer = ByteBuffer.wrap(source)
+
+        val result = packLuminance(buffer, rowStride = rowStride, width = width, height = height)
+
+        val expected = ByteArray(width * height)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                expected[y * width + x] = (y * 10 + x + 1).toByte()
+            }
+        }
+        assertContentEquals(expected, result)
+    }
+
+    @Test
+    fun `result size is always width times height`() {
+        val width = 5
+        val height = 7
+
+        val packed = packLuminance(
+            ByteBuffer.wrap(ByteArray(width * height)),
+            rowStride = width,
+            width = width,
+            height = height
+        )
+        val padded = packLuminance(
+            ByteBuffer.wrap(ByteArray((width + 3) * height)),
+            rowStride = width + 3,
+            width = width,
+            height = height
+        )
+
+        assertEquals(width * height, packed.size)
+        assertEquals(width * height, padded.size)
+    }
+}

--- a/ui/src/androidMain/AndroidManifest.xml
+++ b/ui/src/androidMain/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- QR scanning is a convenience, never a requirement: the form works by hand. -->
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
 
 </manifest>

--- a/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
+++ b/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
@@ -1,0 +1,204 @@
+package com.srfmolina.krocy.ui.presentation.common.scanner
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.compose.CameraXViewfinder
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.core.SurfaceRequest
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import com.srfmolina.krocy.ui.presentation.theme.spacing
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+internal actual val isQrScannerSupported: Boolean = true
+
+@Composable
+internal actual fun CameraQrScanner(
+    onFrame: (QrFrame) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    var permissionGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED
+        )
+    }
+    var permissionDenied by remember { mutableStateOf(false) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        permissionGranted = granted
+        permissionDenied = !granted
+    }
+
+    LaunchedEffect(Unit) {
+        if (!permissionGranted) permissionLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        if (!permissionGranted) {
+            PermissionMessage(denied = permissionDenied, onDismiss = onDismiss)
+            return@Surface
+        }
+
+        var surfaceRequest by remember { mutableStateOf<SurfaceRequest?>(null) }
+        var cameraProvider by remember { mutableStateOf<ProcessCameraProvider?>(null) }
+        val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+        DisposableEffect(Unit) {
+            onDispose {
+                cameraProvider?.unbindAll()
+                analysisExecutor.shutdown()
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            val provider = awaitProcessCameraProvider(context)
+            cameraProvider = provider
+
+            val preview = Preview.Builder().build().apply {
+                setSurfaceProvider { request -> surfaceRequest = request }
+            }
+            val analysis = ImageAnalysis.Builder()
+                // Decoding is slower than capture; queued frames would only ever be stale.
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+                .apply {
+                    setAnalyzer(analysisExecutor) { image ->
+                        try {
+                            onFrame(image.toQrFrame())
+                        } finally {
+                            image.close()
+                        }
+                    }
+                }
+
+            provider.unbindAll()
+            provider.bindToLifecycle(
+                lifecycleOwner,
+                CameraSelector.DEFAULT_BACK_CAMERA,
+                preview,
+                analysis
+            )
+        }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            surfaceRequest?.let { request ->
+                CameraXViewfinder(
+                    surfaceRequest = request,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            Text(
+                text = "Apunta al código QR de Grocy",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(MaterialTheme.spacing.s4)
+            )
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(MaterialTheme.spacing.s4)
+            ) { Text("Cancelar") }
+        }
+    }
+}
+
+@Composable
+private fun PermissionMessage(denied: Boolean, onDismiss: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(MaterialTheme.spacing.s4),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(
+            MaterialTheme.spacing.s3,
+            alignment = Alignment.CenterVertically
+        )
+    ) {
+        Text(
+            text = if (denied) {
+                "Krocy necesita permiso de cámara para leer el código QR. " +
+                    "Puedes concederlo en los ajustes del sistema, o introducir los datos a mano."
+            } else {
+                "Solicitando permiso de cámara…"
+            },
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Button(onClick = onDismiss) { Text("Volver") }
+    }
+}
+
+/**
+ * CameraX 1.6.2 does not ship the `awaitInstance` coroutine extension yet - only the classic
+ * `ListenableFuture` accessor - so this bridges it with `suspendCancellableCoroutine` instead of
+ * pulling in `kotlinx-coroutines-guava` for a single call site.
+ */
+private suspend fun awaitProcessCameraProvider(context: Context): ProcessCameraProvider =
+    suspendCancellableCoroutine { continuation ->
+        val future = ProcessCameraProvider.getInstance(context)
+        future.addListener(
+            { continuation.resume(future.get()) },
+            ContextCompat.getMainExecutor(context)
+        )
+    }
+
+/**
+ * Copies the Y (luminance) plane into a tightly packed buffer. The camera pads rows to a stride
+ * that is often wider than the image, so a straight bulk copy would shear the picture.
+ */
+private fun ImageProxy.toQrFrame(): QrFrame {
+    val plane = planes[0]
+    val buffer = plane.buffer
+    val rowStride = plane.rowStride
+    val data = ByteArray(width * height)
+
+    if (rowStride == width) {
+        buffer.get(data)
+    } else {
+        val row = ByteArray(rowStride)
+        for (y in 0 until height) {
+            buffer.position(y * rowStride)
+            val available = minOf(rowStride, buffer.remaining())
+            buffer.get(row, 0, available)
+            row.copyInto(data, destinationOffset = y * width, startIndex = 0, endIndex = width)
+        }
+    }
+    return QrFrame(luminance = data, width = width, height = height)
+}

--- a/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
+++ b/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
@@ -38,6 +38,8 @@ import com.srfmolina.krocy.domain.model.server.QrFrame
 import com.srfmolina.krocy.ui.presentation.theme.spacing
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 internal actual val isQrScannerSupported: Boolean = true
@@ -57,6 +59,7 @@ internal actual fun CameraQrScanner(
         )
     }
     var permissionDenied by remember { mutableStateOf(false) }
+    var cameraError by remember { mutableStateOf(false) }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -87,33 +90,47 @@ internal actual fun CameraQrScanner(
         }
 
         LaunchedEffect(Unit) {
-            val provider = awaitProcessCameraProvider(context)
-            cameraProvider = provider
+            try {
+                val provider = awaitProcessCameraProvider(context)
+                cameraProvider = provider
 
-            val preview = Preview.Builder().build().apply {
-                setSurfaceProvider { request -> surfaceRequest = request }
-            }
-            val analysis = ImageAnalysis.Builder()
-                // Decoding is slower than capture; queued frames would only ever be stale.
-                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                .build()
-                .apply {
-                    setAnalyzer(analysisExecutor) { image ->
-                        try {
-                            onFrame(image.toQrFrame())
-                        } finally {
-                            image.close()
+                val preview = Preview.Builder().build().apply {
+                    setSurfaceProvider { request -> surfaceRequest = request }
+                }
+                val analysis = ImageAnalysis.Builder()
+                    // Decoding is slower than capture; queued frames would only ever be stale.
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .build()
+                    .apply {
+                        setAnalyzer(analysisExecutor) { image ->
+                            try {
+                                onFrame(image.toQrFrame())
+                            } finally {
+                                image.close()
+                            }
                         }
                     }
-                }
 
-            provider.unbindAll()
-            provider.bindToLifecycle(
-                lifecycleOwner,
-                CameraSelector.DEFAULT_BACK_CAMERA,
-                preview,
-                analysis
-            )
+                provider.unbindAll()
+                provider.bindToLifecycle(
+                    lifecycleOwner,
+                    CameraSelector.DEFAULT_BACK_CAMERA,
+                    preview,
+                    analysis
+                )
+            } catch (e: CancellationException) {
+                throw e // never swallow cancellation
+            } catch (e: Throwable) {
+                // No usable camera, or the provider failed to start. The manifest marks the
+                // camera as not required, so this must degrade to a message rather than take
+                // the app down - the form still works by hand.
+                cameraError = true
+            }
+        }
+
+        if (cameraError) {
+            CameraErrorMessage(onDismiss = onDismiss)
+            return@Surface
         }
 
         Box(modifier = Modifier.fillMaxSize()) {
@@ -165,6 +182,26 @@ private fun PermissionMessage(denied: Boolean, onDismiss: () -> Unit) {
     }
 }
 
+@Composable
+private fun CameraErrorMessage(onDismiss: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(MaterialTheme.spacing.s4),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(
+            MaterialTheme.spacing.s3,
+            alignment = Alignment.CenterVertically
+        )
+    ) {
+        Text(
+            text = "No se ha podido iniciar la cámara. Puedes introducir los datos a mano.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Button(onClick = onDismiss) { Text("Volver") }
+    }
+}
+
 /**
  * CameraX 1.6.2 does not ship the `awaitInstance` coroutine extension yet - only the classic
  * `ListenableFuture` accessor - so this bridges it with `suspendCancellableCoroutine` instead of
@@ -174,9 +211,20 @@ private suspend fun awaitProcessCameraProvider(context: Context): ProcessCameraP
     suspendCancellableCoroutine { continuation ->
         val future = ProcessCameraProvider.getInstance(context)
         future.addListener(
-            { continuation.resume(future.get()) },
+            {
+                try {
+                    continuation.resume(future.get())
+                } catch (e: Throwable) {
+                    // The future completes exceptionally when the provider cannot start. Without
+                    // this the ExecutionException would surface on the main looper as an
+                    // uncaught crash, and the coroutine would park forever with no camera and no
+                    // message.
+                    continuation.resumeWithException(e)
+                }
+            },
             ContextCompat.getMainExecutor(context)
         )
+        continuation.invokeOnCancellation { future.cancel(false) }
     }
 
 /**

--- a/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
+++ b/ui/src/androidMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.android.kt
@@ -1,7 +1,6 @@
 package com.srfmolina.krocy.ui.presentation.common.scanner
 
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,6 +11,7 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
 import androidx.camera.core.SurfaceRequest
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,11 +36,9 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.srfmolina.krocy.domain.model.server.QrFrame
 import com.srfmolina.krocy.ui.presentation.theme.spacing
+import java.nio.ByteBuffer
 import java.util.concurrent.Executors
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.suspendCancellableCoroutine
 
 internal actual val isQrScannerSupported: Boolean = true
 
@@ -91,7 +89,7 @@ internal actual fun CameraQrScanner(
 
         LaunchedEffect(Unit) {
             try {
-                val provider = awaitProcessCameraProvider(context)
+                val provider = ProcessCameraProvider.awaitInstance(context)
                 cameraProvider = provider
 
                 val preview = Preview.Builder().build().apply {
@@ -104,7 +102,14 @@ internal actual fun CameraQrScanner(
                     .apply {
                         setAnalyzer(analysisExecutor) { image ->
                             try {
+                                // A frame we cannot read (an unusual OEM buffer layout, an
+                                // out-of-range stride) is a dropped frame, not a crash - the
+                                // same reasoning as the provider/bind guards above. CameraX
+                                // runs this on its own executor, so an uncaught Throwable here
+                                // would reach the thread's default handler and take the app down.
                                 onFrame(image.toQrFrame())
+                            } catch (e: Throwable) {
+                                // Drop the frame and keep scanning.
                             } finally {
                                 image.close()
                             }
@@ -203,38 +208,21 @@ private fun CameraErrorMessage(onDismiss: () -> Unit) {
 }
 
 /**
- * CameraX 1.6.2 does not ship the `awaitInstance` coroutine extension yet - only the classic
- * `ListenableFuture` accessor - so this bridges it with `suspendCancellableCoroutine` instead of
- * pulling in `kotlinx-coroutines-guava` for a single call site.
- */
-private suspend fun awaitProcessCameraProvider(context: Context): ProcessCameraProvider =
-    suspendCancellableCoroutine { continuation ->
-        val future = ProcessCameraProvider.getInstance(context)
-        future.addListener(
-            {
-                try {
-                    continuation.resume(future.get())
-                } catch (e: Throwable) {
-                    // The future completes exceptionally when the provider cannot start. Without
-                    // this the ExecutionException would surface on the main looper as an
-                    // uncaught crash, and the coroutine would park forever with no camera and no
-                    // message.
-                    continuation.resumeWithException(e)
-                }
-            },
-            ContextCompat.getMainExecutor(context)
-        )
-        continuation.invokeOnCancellation { future.cancel(false) }
-    }
-
-/**
  * Copies the Y (luminance) plane into a tightly packed buffer. The camera pads rows to a stride
  * that is often wider than the image, so a straight bulk copy would shear the picture.
  */
 private fun ImageProxy.toQrFrame(): QrFrame {
     val plane = planes[0]
-    val buffer = plane.buffer
-    val rowStride = plane.rowStride
+    val data = packLuminance(plane.buffer, plane.rowStride, width, height)
+    return QrFrame(luminance = data, width = width, height = height)
+}
+
+/**
+ * Pure pixel-packing logic pulled out of [toQrFrame] so it can be unit-tested without any
+ * CameraX types: copies a possibly row-padded buffer into a tightly packed `width * height`
+ * byte array.
+ */
+internal fun packLuminance(buffer: ByteBuffer, rowStride: Int, width: Int, height: Int): ByteArray {
     val data = ByteArray(width * height)
 
     if (rowStride == width) {
@@ -248,5 +236,5 @@ private fun ImageProxy.toQrFrame(): QrFrame {
             row.copyInto(data, destinationOffset = y * width, startIndex = 0, endIndex = width)
         }
     }
-    return QrFrame(luminance = data, width = width, height = height)
+    return data
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/di/UiModule.kt
@@ -5,6 +5,7 @@ import com.srfmolina.krocy.domain.usecase.login.GetServerConfigUseCase
 import com.srfmolina.krocy.domain.usecase.login.LogoutUseCase
 import com.srfmolina.krocy.domain.usecase.login.ObserveSessionExpiredUseCase
 import com.srfmolina.krocy.domain.usecase.login.OpenSessionUseCase
+import com.srfmolina.krocy.domain.usecase.login.ScanGrocyQrUseCase
 import com.srfmolina.krocy.domain.usecase.login.ValidateServerUseCase
 import com.srfmolina.krocy.domain.usecase.masterdata.GetLocationsUseCase
 import com.srfmolina.krocy.domain.usecase.masterdata.GetProductGroupsUseCase
@@ -57,6 +58,7 @@ val uiModule = module {
     factoryOf(::SetEntryDoneUseCase)
     factoryOf(::AddToShoppingListUseCase)
     factoryOf(::ValidateServerUseCase)
+    factoryOf(::ScanGrocyQrUseCase)
     factoryOf(::CompleteLoginUseCase)
     factoryOf(::OpenSessionUseCase)
     factoryOf(::GetServerConfigUseCase)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.kt
@@ -1,0 +1,19 @@
+package com.srfmolina.krocy.ui.presentation.common.scanner
+
+import androidx.compose.runtime.Composable
+import com.srfmolina.krocy.domain.model.server.QrFrame
+
+/** False where no camera scanner exists; callers must not offer scanning then. */
+internal expect val isQrScannerSupported: Boolean
+
+/**
+ * Full-screen camera viewfinder that emits every analysed frame through [onFrame].
+ *
+ * It decodes nothing and knows nothing about Grocy - the caller decides what a frame means and
+ * when to stop. [onFrame] is called on a camera worker thread.
+ */
+@Composable
+internal expect fun CameraQrScanner(
+    onFrame: (QrFrame) -> Unit,
+    onDismiss: () -> Unit
+)

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.ui.presentation.feature.login.setup
 
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
 import com.srfmolina.krocy.domain.model.server.ServerConfig
 import com.srfmolina.krocy.domain.model.server.hasHttpScheme
 import com.srfmolina.krocy.domain.model.server.normalizeUrlScheme
@@ -56,6 +57,24 @@ internal data class ServerSetupForm(
             } else {
                 ServerConfig.SelfHosted(serverUrl = normalizedUrl, apiKey = key)
             }
+        )
+    }
+
+    /**
+     * Fills the form from a scanned QR. `haToken` is never touched: a Grocy QR cannot carry the
+     * Home Assistant long-lived token, so whatever the user typed must survive the scan.
+     */
+    fun applyQr(credentials: GrocyQrCredentials): ServerSetupForm = when (credentials) {
+        is GrocyQrCredentials.SelfHosted -> copy(
+            usingHass = false,
+            serverUrl = credentials.serverUrl,
+            apiKey = credentials.apiKey
+        )
+        is GrocyQrCredentials.HomeAssistant -> copy(
+            usingHass = true,
+            serverUrl = credentials.haServerUrl,
+            ingressProxyId = credentials.ingressProxyId,
+            apiKey = credentials.apiKey
         )
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
@@ -68,7 +68,8 @@ internal data class ServerSetupForm(
         is GrocyQrCredentials.SelfHosted -> copy(
             usingHass = false,
             serverUrl = credentials.serverUrl,
-            apiKey = credentials.apiKey
+            apiKey = credentials.apiKey,
+            ingressProxyId = ""
         )
         is GrocyQrCredentials.HomeAssistant -> copy(
             usingHass = true,

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupForm.kt
@@ -1,6 +1,8 @@
 package com.srfmolina.krocy.ui.presentation.feature.login.setup
 
 import com.srfmolina.krocy.domain.model.server.ServerConfig
+import com.srfmolina.krocy.domain.model.server.hasHttpScheme
+import com.srfmolina.krocy.domain.model.server.normalizeUrlScheme
 
 internal sealed interface ValidationResult {
     data class Valid(val config: ServerConfig) : ValidationResult
@@ -28,12 +30,9 @@ internal data class ServerSetupForm(
         val token = haToken.trim()
         val proxyId = ingressProxyId.trim()
 
-        // URI schemes are case-insensitive (RFC 3986), so accept e.g. "HTTPS://" as well -
-        // pasted URLs and mobile autocapitalization both produce mixed-case schemes.
         val serverUrlError = when {
             url.isEmpty() -> ERROR_REQUIRED
-            !url.startsWith("http://", ignoreCase = true) &&
-                !url.startsWith("https://", ignoreCase = true) -> ERROR_URL
+            !hasHttpScheme(url) -> ERROR_URL
             else -> null
         }
         val apiKeyError = if (key.isEmpty()) ERROR_REQUIRED else null
@@ -45,13 +44,7 @@ internal data class ServerSetupForm(
         ) {
             return ValidationResult.Invalid(serverUrlError, apiKeyError, haTokenError, proxyIdError)
         }
-        // Normalize only the scheme to lowercase for consistent storage/equality; the host and
-        // path are left untouched since they may be legitimately case-sensitive.
-        val normalizedUrl = when {
-            url.startsWith("https://", ignoreCase = true) -> "https://" + url.substring("https://".length)
-            url.startsWith("http://", ignoreCase = true) -> "http://" + url.substring("http://".length)
-            else -> url
-        }
+        val normalizedUrl = normalizeUrlScheme(url)
         return ValidationResult.Valid(
             if (usingHass) {
                 ServerConfig.HomeAssistant(

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
@@ -11,12 +11,15 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -30,7 +33,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
+import com.srfmolina.krocy.ui.presentation.common.scanner.CameraQrScanner
+import com.srfmolina.krocy.ui.presentation.common.scanner.isQrScannerSupported
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.ConnectionUi
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.Event
 import com.srfmolina.krocy.ui.presentation.theme.spacing
@@ -71,6 +79,22 @@ internal fun ServerSetupScreen(
                 text = "Conectar con tu servidor Grocy",
                 style = MaterialTheme.typography.titleLarge
             )
+
+            if (isQrScannerSupported) {
+                OutlinedButton(
+                    shapes = ButtonDefaults.shapes(),
+                    onClick = { viewModel.launchEvent(Event.OnScanQrClick) },
+                    enabled = !isConnecting,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.QrCodeScanner,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = MaterialTheme.spacing.s2)
+                    )
+                    Text("Escanear código QR")
+                }
+            }
 
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Switch(
@@ -188,6 +212,58 @@ internal fun ServerSetupScreen(
                         }
                     }
                 }
+                is ConnectionUi.QrConfirmation -> Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(
+                        modifier = Modifier.padding(MaterialTheme.spacing.s3),
+                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)
+                    ) {
+                        Text(
+                            text = "Código QR leído",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        val credentials = connection.credentials
+                        val scannedUrl = when (credentials) {
+                            is GrocyQrCredentials.SelfHosted -> credentials.serverUrl
+                            is GrocyQrCredentials.HomeAssistant -> credentials.haServerUrl
+                        }
+                        // The address is the one thing the user must actually check: it came
+                        // from the QR, not from them.
+                        Text(text = scannedUrl, style = MaterialTheme.typography.bodyLarge)
+                        if (credentials is GrocyQrCredentials.HomeAssistant) {
+                            Text(
+                                text = "Modo Home Assistant. Comprueba que esta dirección es la " +
+                                    "de tu servidor antes de introducir tu token de acceso.",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        } else {
+                            Text(
+                                text = "Comprueba que esta dirección es la de tu servidor.",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                        if (connection.isCleartext) {
+                            Text(
+                                text = "Conexión sin cifrar (http) a un servidor fuera de tu red " +
+                                    "local: tus credenciales viajarían visibles por la red.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.s2)) {
+                            OutlinedButton(onClick = {
+                                viewModel.launchEvent(Event.OnQrReject)
+                            }) { Text("Cancelar") }
+                            Button(onClick = {
+                                viewModel.launchEvent(Event.OnQrConfirm)
+                            }) { Text("Usar estos datos") }
+                        }
+                    }
+                }
                 else -> Unit
             }
 
@@ -216,6 +292,18 @@ internal fun ServerSetupScreen(
                     Text(if (isConnecting) "Conectando…" else "Conectar")
                 }
             }
+        }
+    }
+
+    if (state.isScanning) {
+        Dialog(
+            onDismissRequest = { viewModel.launchEvent(Event.OnQrScannerDismiss) },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            CameraQrScanner(
+                onFrame = { frame -> viewModel.launchEvent(Event.OnQrFrame(frame)) },
+                onDismiss = { viewModel.launchEvent(Event.OnQrScannerDismiss) }
+            )
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
+import com.srfmolina.krocy.domain.model.server.isCleartextRisk
 import com.srfmolina.krocy.ui.presentation.common.scanner.CameraQrScanner
 import com.srfmolina.krocy.ui.presentation.common.scanner.isQrScannerSupported
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.ConnectionUi
@@ -116,9 +117,15 @@ internal fun ServerSetupScreen(
                 },
                 supportingText = {
                     val error = state.fieldErrors?.serverUrlError
-                    if (error != null) Text(error)
-                    else if (state.form.usingHass) Text("Ejemplo: http://homeassistant.local:8123")
-                    else Text("Ejemplo: https://grocy.midominio.com")
+                    when {
+                        error != null -> Text(error)
+                        isCleartextRisk(state.form.serverUrl) -> Text(
+                            text = "Conexión sin cifrar: tus credenciales viajarían visibles por la red.",
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        state.form.usingHass -> Text("Ejemplo: http://homeassistant.local:8123")
+                        else -> Text("Ejemplo: https://grocy.midominio.com")
+                    }
                 },
                 isError = state.fieldErrors?.serverUrlError != null,
                 enabled = !isConnecting,
@@ -231,9 +238,25 @@ internal fun ServerSetupScreen(
                             is GrocyQrCredentials.SelfHosted -> credentials.serverUrl
                             is GrocyQrCredentials.HomeAssistant -> credentials.haServerUrl
                         }
-                        // The address is the one thing the user must actually check: it came
-                        // from the QR, not from them.
-                        Text(text = scannedUrl, style = MaterialTheme.typography.bodyLarge)
+                        // The authority (scheme + host + port) is the only part the user can
+                        // actually judge, so it is the prominent element - a long path could
+                        // otherwise push a look-alike host off the visible line.
+                        val schemeSeparator = scannedUrl.indexOf("://")
+                        val pathStart = if (schemeSeparator >= 0) {
+                            scannedUrl.indexOf('/', schemeSeparator + "://".length)
+                        } else {
+                            -1
+                        }
+                        val authority = if (pathStart >= 0) scannedUrl.substring(0, pathStart) else scannedUrl
+                        val path = if (pathStart >= 0) scannedUrl.substring(pathStart) else ""
+                        Text(text = authority, style = MaterialTheme.typography.titleMedium)
+                        if (path.isNotEmpty()) {
+                            Text(
+                                text = path,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                         if (credentials is GrocyQrCredentials.HomeAssistant) {
                             Text(
                                 text = "Modo Home Assistant. Comprueba que esta dirección es la " +

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupScreen.kt
@@ -237,7 +237,7 @@ internal fun ServerSetupScreen(
                         if (credentials is GrocyQrCredentials.HomeAssistant) {
                             Text(
                                 text = "Modo Home Assistant. Comprueba que esta dirección es la " +
-                                    "de tu servidor antes de introducir tu token de acceso.",
+                                    "de tu servidor antes de introducir tu token de acceso de larga duración.",
                                 style = MaterialTheme.typography.bodyMedium
                             )
                         } else {

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
@@ -1,7 +1,12 @@
 package com.srfmolina.krocy.ui.presentation.feature.login.setup
 
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
+import com.srfmolina.krocy.domain.model.server.QrFrame
+import com.srfmolina.krocy.domain.model.server.QrScanOutcome
 import com.srfmolina.krocy.domain.model.server.ServerConfig
+import com.srfmolina.krocy.domain.model.server.isCleartextRisk
 import com.srfmolina.krocy.domain.usecase.login.CompleteLoginUseCase
+import com.srfmolina.krocy.domain.usecase.login.ScanGrocyQrUseCase
 import com.srfmolina.krocy.domain.usecase.login.ValidateServerUseCase
 import com.srfmolina.krocy.ui.base.BaseViewModel
 import com.srfmolina.krocy.ui.base.UiEffect
@@ -11,9 +16,12 @@ import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewMo
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.Event
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.State
 
+private const val ERROR_QR_NOT_GROCY = "El código QR no pertenece a un servidor Grocy"
+
 internal class ServerSetupViewModel(
     private val validateServer: ValidateServerUseCase,
-    private val completeLogin: CompleteLoginUseCase
+    private val completeLogin: CompleteLoginUseCase,
+    private val scanGrocyQr: ScanGrocyQrUseCase
 ) : BaseViewModel<Event, State, Effect>() {
 
     sealed interface Event : UiEvent {
@@ -25,6 +33,11 @@ internal class ServerSetupViewModel(
         data object OnConnectClick : Event
         data object OnContinueAnyway : Event
         data object OnDismissWarning : Event
+        data object OnScanQrClick : Event
+        data class OnQrFrame(val frame: QrFrame) : Event
+        data object OnQrScannerDismiss : Event
+        data object OnQrConfirm : Event
+        data object OnQrReject : Event
     }
 
     sealed interface Effect : UiEffect {
@@ -36,12 +49,25 @@ internal class ServerSetupViewModel(
         data object Connecting : ConnectionUi
         data class Error(val message: String, val detail: String?) : ConnectionUi
         data class VersionWarning(val version: String) : ConnectionUi
+
+        /**
+         * A scan produced credentials, and the user has not vouched for them yet.
+         *
+         * Nothing is written to the form until they do. The host in a QR is chosen by whoever
+         * printed it, and in Home Assistant mode the user is about to type a long-lived token
+         * into a form pointed at that host - so the address gets shown and confirmed first.
+         */
+        data class QrConfirmation(
+            val credentials: GrocyQrCredentials,
+            val isCleartext: Boolean
+        ) : ConnectionUi
     }
 
     data class State(
         val form: ServerSetupForm = ServerSetupForm(),
         val fieldErrors: ValidationResult.Invalid? = null,
-        val connection: ConnectionUi = ConnectionUi.Idle
+        val connection: ConnectionUi = ConnectionUi.Idle,
+        val isScanning: Boolean = false
     ) : UiState
 
     override fun createInitialState(): State = State()
@@ -59,11 +85,71 @@ internal class ServerSetupViewModel(
                 pendingConfig = null
                 setState { copy(connection = ConnectionUi.Idle) }
             }
+            is Event.OnScanQrClick -> setState {
+                copy(isScanning = true, fieldErrors = null, connection = ConnectionUi.Idle)
+            }
+            is Event.OnQrScannerDismiss -> setState { copy(isScanning = false) }
+            is Event.OnQrFrame -> processQrFrame(event.frame)
+            is Event.OnQrConfirm -> {
+                val pending = currentState.connection as? ConnectionUi.QrConfirmation
+                if (pending != null) {
+                    setState {
+                        copy(
+                            form = form.applyQr(pending.credentials),
+                            fieldErrors = null,
+                            connection = ConnectionUi.Idle
+                        )
+                    }
+                }
+            }
+            is Event.OnQrReject -> setState { copy(connection = ConnectionUi.Idle) }
         }
     }
 
     /** Config that passed validation but reported an unsupported version. */
     private var pendingConfig: ServerConfig? = null
+
+    /**
+     * The camera produces frames far faster than ZXing consumes them; without this guard every
+     * dropped frame would still queue a decode and the backlog would outlive the scan.
+     */
+    private var decodingFrame = false
+
+    private suspend fun processQrFrame(frame: QrFrame) {
+        if (!currentState.isScanning || decodingFrame) return
+        decodingFrame = true
+        try {
+            // A decoder crash is treated as "not a Grocy QR": the user gets an actionable
+            // message instead of a silent camera that never resolves.
+            val outcome = scanGrocyQr(frame).getOrElse { QrScanOutcome.NotGrocy }
+            when (outcome) {
+                is QrScanOutcome.NotFound -> Unit // still aiming
+                is QrScanOutcome.NotGrocy -> setState {
+                    copy(
+                        isScanning = false,
+                        connection = ConnectionUi.Error(ERROR_QR_NOT_GROCY, null)
+                    )
+                }
+                is QrScanOutcome.Found -> {
+                    val serverUrl = when (val credentials = outcome.credentials) {
+                        is GrocyQrCredentials.SelfHosted -> credentials.serverUrl
+                        is GrocyQrCredentials.HomeAssistant -> credentials.haServerUrl
+                    }
+                    setState {
+                        copy(
+                            isScanning = false,
+                            connection = ConnectionUi.QrConfirmation(
+                                credentials = outcome.credentials,
+                                isCleartext = isCleartextRisk(serverUrl)
+                            )
+                        )
+                    }
+                }
+            }
+        } finally {
+            decodingFrame = false
+        }
+    }
 
     private fun updateForm(reduce: ServerSetupForm.() -> ServerSetupForm) {
         setState { copy(form = form.reduce(), fieldErrors = null, connection = ConnectionUi.Idle) }

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
@@ -122,6 +122,10 @@ internal class ServerSetupViewModel(
             // A decoder crash is treated as "not a Grocy QR": the user gets an actionable
             // message instead of a silent camera that never resolves.
             val outcome = scanGrocyQr(frame).getOrElse { QrScanOutcome.NotGrocy }
+            // Events run in their own coroutines, so the scanner can be dismissed while this
+            // decode is in flight. A result that lands afterwards belongs to a scan the user
+            // already closed and must not reopen it as a confirmation or an error.
+            if (!currentState.isScanning) return
             when (outcome) {
                 is QrScanOutcome.NotFound -> Unit // still aiming
                 is QrScanOutcome.NotGrocy -> setState {

--- a/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
+++ b/ui/src/commonMain/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModel.kt
@@ -152,7 +152,15 @@ internal class ServerSetupViewModel(
     }
 
     private fun updateForm(reduce: ServerSetupForm.() -> ServerSetupForm) {
-        setState { copy(form = form.reduce(), fieldErrors = null, connection = ConnectionUi.Idle) }
+        setState {
+            copy(
+                form = form.reduce(),
+                fieldErrors = null,
+                // A pending QR confirmation survives a keystroke elsewhere in the form; only
+                // dropping otherwise clears connection state (an error, a version warning...).
+                connection = if (connection is ConnectionUi.QrConfirmation) connection else ConnectionUi.Idle
+            )
+        }
     }
 
     private suspend fun connect() {

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupFormTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupFormTest.kt
@@ -1,5 +1,6 @@
 package com.srfmolina.krocy.ui.presentation.feature.login.setup
 
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
 import com.srfmolina.krocy.domain.model.server.LoginFailure
 import com.srfmolina.krocy.domain.model.server.ServerConfig
 import kotlin.test.Test
@@ -132,5 +133,33 @@ class ServerSetupFormTest {
         val mapped = throwable.toLoginMessage()
         assertEquals("Error inesperado", mapped.message)
         assertEquals(throwable.toString(), mapped.detail)
+    }
+
+    @Test
+    fun `applying a self hosted qr fills the form and leaves hass mode off`() {
+        val form = ServerSetupForm(usingHass = true, haToken = "lltoken")
+            .applyQr(GrocyQrCredentials.SelfHosted("https://grocy.casa", "key123"))
+
+        assertEquals(false, form.usingHass)
+        assertEquals("https://grocy.casa", form.serverUrl)
+        assertEquals("key123", form.apiKey)
+    }
+
+    @Test
+    fun `applying a hass qr switches to hass mode and preserves a typed token`() {
+        val form = ServerSetupForm(haToken = "lltoken")
+            .applyQr(
+                GrocyQrCredentials.HomeAssistant(
+                    haServerUrl = "http://ha.local:8123",
+                    ingressProxyId = "proxy-id",
+                    apiKey = "key123"
+                )
+            )
+
+        assertEquals(true, form.usingHass)
+        assertEquals("http://ha.local:8123", form.serverUrl)
+        assertEquals("proxy-id", form.ingressProxyId)
+        assertEquals("key123", form.apiKey)
+        assertEquals("lltoken", form.haToken) // the QR never carries it; never clobber it
     }
 }

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
@@ -466,6 +466,50 @@ class ServerSetupViewModelTest {
     }
 
     @Test
+    fun `a decode landing after the scanner is dismissed raises no confirmation`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gate = CompletableDeferred<Unit>()
+        val qrRepo = QrScannerRepositoryFake {
+            gate.await()
+            "https://grocy.casa/api|key"
+        }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnQrScannerDismiss) // the user cancels mid-decode
+        advanceUntilIdle()
+        gate.complete(Unit) // and only then does the decode land
+        advanceUntilIdle()
+
+        assertFalse(vm.currentState.isScanning)
+        assertEquals(ConnectionUi.Idle, vm.currentState.connection)
+        assertEquals(ServerSetupForm(), vm.currentState.form)
+    }
+
+    @Test
+    fun `a non grocy decode landing after the scanner is dismissed raises no error`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gate = CompletableDeferred<Unit>()
+        val qrRepo = QrScannerRepositoryFake {
+            gate.await()
+            "WIFI:S:MiRed;;"
+        }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnQrScannerDismiss)
+        advanceUntilIdle()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionUi.Idle, vm.currentState.connection)
+    }
+
+    @Test
     fun `OnQrConfirm is a no-op when there is no pending confirmation`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) })

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
@@ -1,12 +1,16 @@
 package com.srfmolina.krocy.ui.presentation.feature.login.setup
 
+import com.srfmolina.krocy.domain.model.server.GrocyQrCredentials
 import com.srfmolina.krocy.domain.model.server.LoginFailure
+import com.srfmolina.krocy.domain.model.server.QrFrame
 import com.srfmolina.krocy.domain.model.server.ServerConfig
 import com.srfmolina.krocy.domain.model.server.ServerValidation
 import com.srfmolina.krocy.domain.repository.LoginRepository
+import com.srfmolina.krocy.domain.repository.QrScannerRepository
 import com.srfmolina.krocy.domain.repository.ServerConfigRepository
 import com.srfmolina.krocy.domain.session.SessionManager
 import com.srfmolina.krocy.domain.usecase.login.CompleteLoginUseCase
+import com.srfmolina.krocy.domain.usecase.login.ScanGrocyQrUseCase
 import com.srfmolina.krocy.domain.usecase.login.ValidateServerUseCase
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.ConnectionUi
 import com.srfmolina.krocy.ui.presentation.feature.login.setup.ServerSetupViewModel.Effect
@@ -25,7 +29,10 @@ import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServerSetupViewModelTest {
@@ -54,13 +61,25 @@ class ServerSetupViewModelTest {
         override suspend fun close() = Unit
     }
 
+    private class QrScannerRepositoryFake(
+        var onDecode: suspend (QrFrame) -> String? = { null }
+    ) : QrScannerRepository {
+        var callCount = 0
+        override suspend fun decode(frame: QrFrame): String? {
+            callCount++
+            return onDecode(frame)
+        }
+    }
+
     private fun viewModel(
         loginRepo: LoginRepository,
         configRepo: ServerConfigRepository = ServerConfigRepositoryFake(),
-        sessionManager: SessionManager = SessionManagerFake()
+        sessionManager: SessionManager = SessionManagerFake(),
+        qrRepo: QrScannerRepository = QrScannerRepositoryFake()
     ) = ServerSetupViewModel(
         validateServer = ValidateServerUseCase(loginRepo),
-        completeLogin = CompleteLoginUseCase(configRepo, sessionManager)
+        completeLogin = CompleteLoginUseCase(configRepo, sessionManager),
+        scanGrocyQr = ScanGrocyQrUseCase(qrRepo)
     )
 
     private val validSelfHostedForm = ServerSetupForm(
@@ -268,5 +287,166 @@ class ServerSetupViewModelTest {
         assertEquals(1, sessionManager.openCallCount)
         assertEquals(listOf<Effect>(Effect.NavigateToStock), effects)
         collector.cancel()
+    }
+
+    private val anyFrame = QrFrame(luminance = ByteArray(4), width = 2, height = 2)
+
+    @Test
+    fun `scan click opens the scanner`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) })
+
+        vm.launchEvent(Event.OnScanQrClick)
+        advanceUntilIdle()
+
+        assertTrue(vm.currentState.isScanning)
+    }
+
+    @Test
+    fun `dismissing closes the scanner`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) })
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrScannerDismiss)
+        advanceUntilIdle()
+
+        assertFalse(vm.currentState.isScanning)
+    }
+
+    @Test
+    fun `a grocy qr closes the scanner and asks the user to confirm the host`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "http://ha.local:8123/api/hassio_ingress/px/api|k" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+
+        assertFalse(vm.currentState.isScanning)
+        // Nothing is applied until the user vouches for the host.
+        assertEquals(ServerSetupForm(), vm.currentState.form)
+        val connection = vm.currentState.connection
+        assertIs<ConnectionUi.QrConfirmation>(connection)
+        assertEquals(
+            GrocyQrCredentials.HomeAssistant("http://ha.local:8123", "px", "k"),
+            connection.credentials
+        )
+        assertFalse(connection.isCleartext) // .local is the user's own network
+    }
+
+    @Test
+    fun `confirming applies the scanned credentials to the form`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "http://ha.local:8123/api/hassio_ingress/px/api|k" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnQrConfirm)
+        advanceUntilIdle()
+
+        assertTrue(vm.currentState.form.usingHass)
+        assertEquals("http://ha.local:8123", vm.currentState.form.serverUrl)
+        assertEquals("px", vm.currentState.form.ingressProxyId)
+        assertEquals("k", vm.currentState.form.apiKey)
+        assertEquals(ConnectionUi.Idle, vm.currentState.connection)
+    }
+
+    @Test
+    fun `rejecting the confirmation leaves the form untouched`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "https://evil.host/api|stolen" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnQrReject)
+        advanceUntilIdle()
+
+        assertEquals(ServerSetupForm(), vm.currentState.form)
+        assertEquals(ConnectionUi.Idle, vm.currentState.connection)
+    }
+
+    @Test
+    fun `a cleartext public host is flagged in the confirmation`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "http://grocy.midominio.com/api|k" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+
+        val connection = vm.currentState.connection
+        assertIs<ConnectionUi.QrConfirmation>(connection)
+        assertTrue(connection.isCleartext)
+    }
+
+    @Test
+    fun `a non grocy qr closes the scanner and shows an error`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "WIFI:S:MiRed;;" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+
+        assertFalse(vm.currentState.isScanning)
+        val connection = vm.currentState.connection
+        assertIs<ConnectionUi.Error>(connection)
+        assertEquals("El código QR no pertenece a un servidor Grocy", connection.message)
+    }
+
+    @Test
+    fun `a frame without a qr changes nothing and keeps scanning`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { null }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+
+        assertTrue(vm.currentState.isScanning)
+        assertEquals(ServerSetupForm(), vm.currentState.form)
+    }
+
+    @Test
+    fun `frames arriving while a decode is in flight are dropped`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gate = CompletableDeferred<Unit>()
+        val qrRepo = QrScannerRepositoryFake {
+            gate.await()
+            "https://grocy.casa/api|key"
+        }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        advanceUntilIdle()
+        repeat(5) { vm.launchEvent(Event.OnQrFrame(anyFrame)) }
+        advanceUntilIdle()
+
+        assertEquals(1, qrRepo.callCount) // the camera outruns the decoder; only one gets through
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertIs<ConnectionUi.QrConfirmation>(vm.currentState.connection)
+    }
+
+    @Test
+    fun `frames arriving after the scanner closed are ignored`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "https://grocy.casa/api|key" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnQrFrame(anyFrame)) // scanner never opened
+        advanceUntilIdle()
+
+        assertEquals(0, qrRepo.callCount)
+        assertEquals(ServerSetupForm(), vm.currentState.form)
     }
 }

--- a/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
+++ b/ui/src/commonTest/kotlin/com/srfmolina/krocy/ui/presentation/feature/login/setup/ServerSetupViewModelTest.kt
@@ -449,4 +449,30 @@ class ServerSetupViewModelTest {
         assertEquals(0, qrRepo.callCount)
         assertEquals(ServerSetupForm(), vm.currentState.form)
     }
+
+    @Test
+    fun `editing a field keeps a pending qr confirmation`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val qrRepo = QrScannerRepositoryFake { "https://grocy.casa/api|key" }
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) }, qrRepo = qrRepo)
+
+        vm.launchEvent(Event.OnScanQrClick)
+        vm.launchEvent(Event.OnQrFrame(anyFrame))
+        advanceUntilIdle()
+        vm.launchEvent(Event.OnApiKeyChange("typed"))
+        advanceUntilIdle()
+
+        assertIs<ConnectionUi.QrConfirmation>(vm.currentState.connection)
+    }
+
+    @Test
+    fun `OnQrConfirm is a no-op when there is no pending confirmation`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(LoginRepositoryFake { ServerValidation("4.0.0", true) })
+
+        vm.launchEvent(Event.OnQrConfirm)
+        advanceUntilIdle()
+
+        assertEquals(ServerSetupForm(), vm.currentState.form)
+    }
 }

--- a/ui/src/jvmMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.jvm.kt
+++ b/ui/src/jvmMain/kotlin/com/srfmolina/krocy/ui/presentation/common/scanner/QrScanner.jvm.kt
@@ -1,0 +1,13 @@
+package com.srfmolina.krocy.ui.presentation.common.scanner
+
+import androidx.compose.runtime.Composable
+import com.srfmolina.krocy.domain.model.server.QrFrame
+
+/** Desktop has no camera scanner; the setup screen hides the scan button entirely. */
+internal actual val isQrScannerSupported: Boolean = false
+
+@Composable
+internal actual fun CameraQrScanner(
+    onFrame: (QrFrame) -> Unit,
+    onDismiss: () -> Unit
+) = Unit


### PR DESCRIPTION
# QR login

Closes the QR-code login follow-up left open in PR #25 §14.

Connecting Krocy to a Grocy server meant typing a URL, an API key and — behind the Home
Assistant add-on — an ingress proxy id, by hand, on a phone. Grocy already publishes all of
that as a QR code. Now Krocy reads it.

Scanning is **Android only**. Desktop keeps the hand-entry form untouched: `isQrScannerSupported`
is `false` there, so the button never renders.

## The payload

Both QR variants are one line, `<apiBaseUrl>|<apiKey>`:

| Source | Example |
|---|---|
| Self-hosted Grocy | `http://10.10.10.11:8080/api\|LwasdaXXXXXXXXXXXXXXX` |
| Grocy add-on behind HA ingress | `http://192.168.1.20:8123/api/hassio_ingress/<proxyId>/api\|vXNvFXXXXXXXX` |

The Home Assistant payload carries everything `ServerConfig.HomeAssistant` needs **except the
long-lived token**, which is minted in Home Assistant and can never appear in a Grocy QR — so
the user still types that one field.

## Flow

Scan → the camera closes and a card shows the address that was read → the user accepts or
cancels → only then is the form filled → "Conectar" runs the existing validation path unchanged.

Nothing scanned is persisted directly: it populates form fields and goes through
`ValidateServerUseCase` → `CompleteLoginUseCase` like typed input, so the connection test, the
version gate and encryption-at-rest all still apply.

## Architecture

Dependency direction `ui → domain ← data` is preserved. CameraX types never leave `:ui`;
ZXing types never leave `:data`.

```
:ui      CameraQrScanner (CameraX) ──QrFrame──▶ ServerSetupViewModel
                                                       │
:domain                                       ScanGrocyQrUseCase
                                                  │         │
                                        QrScannerRepository  GrocyQrCredentials.parse
:data                              QrScannerRepositoryImpl
                                                  │
                                          ZxingQrDecoder
```

- **`:domain`** — `GrocyQrCredentials` (sealed `SelfHosted`/`HomeAssistant`) with a strict
  `parse()`; `QrFrame`; `QrScanOutcome` (`NotFound`/`NotGrocy`/`Found`); `QrScannerRepository`;
  `ScanGrocyQrUseCase`; and `UrlNormalization.kt`, which now also backs `ServerSetupForm`'s
  scheme rules so the parser and the form cannot drift apart.
- **`:data`** — a single `ZxingQrDecoder` in a new `jvmCommonMain` source set shared by
  `androidMain` and `jvmMain` (ZXing is a plain Java jar and cannot be declared in a KMP
  `commonMain`), reached from `commonMain` through `expect fun createQrDecoder()`, mirroring the
  existing `createCredentialCipher()` pattern. Registered in the **root** `dataModule`, not
  `sessionModule` — scanning happens while logged out, before a session exists.
- **`:ui`** — `isQrScannerSupported` + `CameraQrScanner` as `expect`/`actual`. Android uses
  CameraX 1.6.2 (`camera-core`, `camera-camera2`, `camera-lifecycle`, `camera-compose`) with
  `CameraXViewfinder` and an `ImageAnalysis` pipeline on `STRATEGY_KEEP_ONLY_LATEST`; the
  analyzer copies the Y plane and hands it out, holding no logic of its own.

`QrScanOutcome` has three cases on purpose. Most frames contain no QR and must be ignored in
silence, but a QR that is *not* a Grocy payload has to raise an error — otherwise the user aims
at the wrong code and watches nothing happen forever.

## Dependencies

CameraX `1.6.2` and ZXing core `3.5.3` — both Apache-2.0, no Google Play Services, no ML Kit.
`zxing-android-embedded` was rejected as Activity/View-based over the deprecated Camera1 API.
The `CAMERA` permission ships with a `camera.any` `uses-feature` marked `required="false"`, so
the app still installs on cameraless devices and degrades to hand entry.

## Security

A scanned QR is **attacker-controllable input** — a sticker, a printed sheet, an image on a
page. Unlike a typed URL, the user did not choose the host. The worst case is Home Assistant
mode: a QR can silently switch the form into HA mode and fill in a host the attacker owns, and
the user then types their real long-lived token into a form aimed at that host.

Two answers, since neither alone is enough:

**1. Strict validation at the parse boundary.** `GrocyQrCredentials.parse` is the only place that
decides a payload is acceptable. Rejected:

| Rejected | Why |
|---|---|
| Control characters, CR/LF in the key | The key is sent verbatim as `GROCY-API-KEY`; a CR is header injection |
| Userinfo, including percent-encoded `%40` | `grocy.midominio.com@evil.host` shows a host the user trusts and connects to one they don't |
| Non-ASCII hosts | Homograph lookalikes; real servers use punycode |
| An authority outside `[A-Za-z0-9._~\-:\[\]]` | The authority must be exactly what it looks like |
| `?`, `#`, `\`, `//`, `.`/`..` segments | Ways to make the request differ from the URL on screen |
| A proxy id outside `[A-Za-z0-9_.-]` | It is interpolated into `<haUrl>/api/hassio_ingress/<id>` |
| Payloads > 2048 B, URLs > 256, keys > 512 | A QR carries ~4 KB; an overlong URL exists only to push the confirmation card off screen |

**2. A confirmation card.** No parser can judge whether a syntactically valid host is *yours*, so
a scan writes **nothing** to the form until the user accepts the address shown. The host is
rendered apart from the path so a lookalike cannot hide in a long URL, and plain `http` to a
host outside RFC1918 / `.local` / loopback is flagged in red — on the card, and afterwards on
the URL field itself, so the warning is still on screen while the token is typed.

Decoded payloads are never logged and never echoed into the UI: the "not a Grocy QR" error
carries a `null` detail deliberately, since the payload may be someone's credential or text
aimed at whoever reads the screen. This also closes, for the scanned path only, the cleartext
warning deferred in PR #25 §12.

## Tests

375 JVM tests, 0 failures — `:domain:jvmTest` 46, `:data:jvmTest` 103, `:ui:jvmTest` 226 — plus
`:ui:testDebugUnitTest` and `:data:testDebugUnitTest` to prove the Android target compiles.

| Suite | Covers |
|---|---|
| `GrocyQrCredentialsTest` | Both real payloads plus every rejection above |
| `UrlNormalizationTest` | Cleartext classification, incl. public hosts that merely look private (`10.attacker.com`) |
| `ScanGrocyQrUseCaseTest` | The three outcomes and decoder failure |
| `ZxingQrDecoderTest` | Round trip against QR images generated by ZXing's own writer; blank and undersized frames |
| `PackLuminanceTest` | The stride-aware Y-plane packing, incl. padded rows |
| `ServerSetupFormTest` / `ServerSetupViewModelTest` | `applyQr`, the confirm/reject flow, the in-flight frame guard, the error paths |

The Android camera `actual` has no unit tests by design — it was built to hold no logic, which
is why the one piece of real logic in it (`packLuminance`) was extracted and tested separately.

## Still to verify on a device

- The stride path on hardware where `rowStride != width` — if it were wrong, frames would simply
  never decode, which looks identical to bad aim.
- The confirmation card fully visible without scrolling on a small phone in HA mode.
- Permission prompt on first scan, and the permanently-denied message.
- A non-Grocy QR (WiFi code) closing the scanner with the error card.
- A cameraless device, or the camera held by another app.
- One end-to-end HA login from a real add-on QR.

## Docs

`Server Login & Session System (PR 25).md` gains a section on the payload, the parsing rules and
the layer split; its security table gains a row for scanned input; and the QR-out-of-scope entry
is retired.
